### PR TITLE
feat: add schema v1 domain and YAML loaders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -50,4 +50,7 @@ golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -1,0 +1,149 @@
+package domain
+
+const CurrentSchemaVersion = 1
+
+type SchemaVersion int
+
+type PageSize string
+
+const (
+	PageSizeA3 PageSize = "A3"
+	PageSizeA4 PageSize = "A4"
+	PageSizeA5 PageSize = "A5"
+	PageSizeA6 PageSize = "A6"
+)
+
+type Orientation string
+
+const (
+	OrientationPortrait  Orientation = "portrait"
+	OrientationLandscape Orientation = "landscape"
+)
+
+type ExportFormat string
+
+const (
+	ExportFormatPDF ExportFormat = "pdf"
+	ExportFormatPNG ExportFormat = "png"
+	ExportFormatSVG ExportFormat = "svg"
+)
+
+type SlotType string
+
+const (
+	SlotTypeText       SlotType = "text"
+	SlotTypeImage      SlotType = "image"
+	SlotTypeDecoration SlotType = "decoration"
+)
+
+type TextAlign string
+
+const (
+	TextAlignLeft   TextAlign = "left"
+	TextAlignCenter TextAlign = "center"
+	TextAlignRight  TextAlign = "right"
+)
+
+type OverflowMode string
+
+const (
+	OverflowModeClip     OverflowMode = "clip"
+	OverflowModeTruncate OverflowMode = "truncate"
+	OverflowModeError    OverflowMode = "error"
+)
+
+type FitMode string
+
+const (
+	FitModeContain FitMode = "contain"
+	FitModeCover   FitMode = "cover"
+)
+
+type AssetKind string
+
+const (
+	AssetKindDecoration AssetKind = "decoration"
+	AssetKindImage      AssetKind = "image"
+	AssetKindFont       AssetKind = "font"
+)
+
+type Project struct {
+	Version  SchemaVersion  `yaml:"version"`
+	Template string         `yaml:"template"`
+	Page     ProjectPage    `yaml:"page"`
+	Content  Content        `yaml:"content,omitempty"`
+	Images   []ImageBinding `yaml:"images,omitempty"`
+	Options  ProjectOptions `yaml:"options,omitempty"`
+	Export   ExportOptions  `yaml:"export,omitempty"`
+}
+
+type ProjectPage struct {
+	Size        PageSize    `yaml:"size"`
+	Orientation Orientation `yaml:"orientation"`
+}
+
+type Content struct {
+	Title     string `yaml:"title,omitempty"`
+	Body      string `yaml:"body,omitempty"`
+	Signature string `yaml:"signature,omitempty"`
+}
+
+type ImageBinding struct {
+	Slot string `yaml:"slot"`
+	Path string `yaml:"path"`
+}
+
+type ProjectOptions struct {
+	Decorations bool `yaml:"decorations,omitempty"`
+}
+
+type ExportOptions struct {
+	Format ExportFormat `yaml:"format,omitempty"`
+	Out    string       `yaml:"out,omitempty"`
+}
+
+type Template struct {
+	Version SchemaVersion    `yaml:"version"`
+	ID      string           `yaml:"id"`
+	Page    TemplatePage     `yaml:"page"`
+	Layout  Layout           `yaml:"layout,omitempty"`
+	Slots   []Slot           `yaml:"slots"`
+	Styles  map[string]Style `yaml:"styles,omitempty"`
+	Assets  []Asset          `yaml:"assets,omitempty"`
+}
+
+type TemplatePage struct {
+	SupportedSizes     []PageSize  `yaml:"supported_sizes"`
+	DefaultOrientation Orientation `yaml:"default_orientation"`
+}
+
+type Layout struct {
+	MarginMM float64 `yaml:"margin_mm,omitempty"`
+}
+
+type Slot struct {
+	ID       string   `yaml:"id"`
+	Type     SlotType `yaml:"type"`
+	XMM      float64  `yaml:"x_mm"`
+	YMM      float64  `yaml:"y_mm"`
+	WMM      float64  `yaml:"w_mm"`
+	HMM      float64  `yaml:"h_mm"`
+	Style    string   `yaml:"style,omitempty"`
+	Fit      FitMode  `yaml:"fit,omitempty"`
+	Required bool     `yaml:"required,omitempty"`
+}
+
+type Style struct {
+	Font       string       `yaml:"font"`
+	SizePt     float64      `yaml:"size_pt"`
+	LineHeight float64      `yaml:"line_height,omitempty"`
+	Align      TextAlign    `yaml:"align,omitempty"`
+	MaxLines   int          `yaml:"max_lines,omitempty"`
+	Overflow   OverflowMode `yaml:"overflow,omitempty"`
+}
+
+type Asset struct {
+	ID   string    `yaml:"id"`
+	Kind AssetKind `yaml:"kind"`
+	Path string    `yaml:"path"`
+}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -1,0 +1,246 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	if e.Field == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+type ValidationErrors []ValidationError
+
+func (errs ValidationErrors) Error() string {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		parts = append(parts, err.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (errs ValidationErrors) add(field, message string) ValidationErrors {
+	return append(errs, ValidationError{
+		Field:   field,
+		Message: message,
+	})
+}
+
+func (errs ValidationErrors) err() error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs
+}
+
+func (p Project) Validate() error {
+	var errs ValidationErrors
+
+	if p.Version != CurrentSchemaVersion {
+		errs = errs.add("version", fmt.Sprintf("must be %d", CurrentSchemaVersion))
+	}
+	if strings.TrimSpace(p.Template) == "" {
+		errs = errs.add("template", "is required")
+	}
+	if !p.Page.Size.valid() {
+		errs = errs.add("page.size", "must be one of A3, A4, A5, or A6")
+	}
+	if !p.Page.Orientation.valid() {
+		errs = errs.add("page.orientation", "must be portrait or landscape")
+	}
+	if p.Export.Format != "" && !p.Export.Format.valid() {
+		errs = errs.add("export.format", "must be one of pdf, png, or svg")
+	}
+
+	for i, image := range p.Images {
+		if strings.TrimSpace(image.Slot) == "" {
+			errs = errs.add(fmt.Sprintf("images[%d].slot", i), "is required")
+		}
+		if strings.TrimSpace(image.Path) == "" {
+			errs = errs.add(fmt.Sprintf("images[%d].path", i), "is required")
+		}
+	}
+
+	return errs.err()
+}
+
+func (t Template) Validate() error {
+	var errs ValidationErrors
+
+	if t.Version != CurrentSchemaVersion {
+		errs = errs.add("version", fmt.Sprintf("must be %d", CurrentSchemaVersion))
+	}
+	if strings.TrimSpace(t.ID) == "" {
+		errs = errs.add("id", "is required")
+	}
+	if len(t.Page.SupportedSizes) == 0 {
+		errs = errs.add("page.supported_sizes", "must include at least one page size")
+	}
+	for i, size := range t.Page.SupportedSizes {
+		if !size.valid() {
+			errs = errs.add(fmt.Sprintf("page.supported_sizes[%d]", i), "must be one of A3, A4, A5, or A6")
+		}
+	}
+	if !t.Page.DefaultOrientation.valid() {
+		errs = errs.add("page.default_orientation", "must be portrait or landscape")
+	}
+	if t.Layout.MarginMM < 0 {
+		errs = errs.add("layout.margin_mm", "must be greater than or equal to 0")
+	}
+	if len(t.Slots) == 0 {
+		errs = errs.add("slots", "must include at least one slot")
+	}
+
+	seenSlots := map[string]struct{}{}
+	for i, slot := range t.Slots {
+		fieldPrefix := fmt.Sprintf("slots[%d]", i)
+		if strings.TrimSpace(slot.ID) == "" {
+			errs = errs.add(fieldPrefix+".id", "is required")
+		} else {
+			if _, exists := seenSlots[slot.ID]; exists {
+				errs = errs.add(fieldPrefix+".id", "must be unique")
+			}
+			seenSlots[slot.ID] = struct{}{}
+		}
+		if !slot.Type.valid() {
+			errs = errs.add(fieldPrefix+".type", "must be one of text, image, or decoration")
+		}
+		if slot.WMM <= 0 {
+			errs = errs.add(fieldPrefix+".w_mm", "must be greater than 0")
+		}
+		if slot.HMM <= 0 {
+			errs = errs.add(fieldPrefix+".h_mm", "must be greater than 0")
+		}
+		if slot.Fit != "" && !slot.Fit.valid() {
+			errs = errs.add(fieldPrefix+".fit", "must be contain or cover")
+		}
+		if slot.Style != "" {
+			if _, ok := t.Styles[slot.Style]; !ok {
+				errs = errs.add(fieldPrefix+".style", "must reference a defined style")
+			}
+		}
+	}
+
+	for name, style := range t.Styles {
+		fieldPrefix := fmt.Sprintf("styles.%s", name)
+		if strings.TrimSpace(style.Font) == "" {
+			errs = errs.add(fieldPrefix+".font", "is required")
+		}
+		if style.SizePt <= 0 {
+			errs = errs.add(fieldPrefix+".size_pt", "must be greater than 0")
+		}
+		if style.LineHeight < 0 {
+			errs = errs.add(fieldPrefix+".line_height", "must be greater than or equal to 0")
+		}
+		if style.Align != "" && !style.Align.valid() {
+			errs = errs.add(fieldPrefix+".align", "must be left, center, or right")
+		}
+		if style.MaxLines < 0 {
+			errs = errs.add(fieldPrefix+".max_lines", "must be greater than or equal to 0")
+		}
+		if style.Overflow != "" && !style.Overflow.valid() {
+			errs = errs.add(fieldPrefix+".overflow", "must be clip, truncate, or error")
+		}
+	}
+
+	seenAssets := map[string]struct{}{}
+	for i, asset := range t.Assets {
+		fieldPrefix := fmt.Sprintf("assets[%d]", i)
+		if strings.TrimSpace(asset.ID) == "" {
+			errs = errs.add(fieldPrefix+".id", "is required")
+		} else {
+			if _, exists := seenAssets[asset.ID]; exists {
+				errs = errs.add(fieldPrefix+".id", "must be unique")
+			}
+			seenAssets[asset.ID] = struct{}{}
+		}
+		if !asset.Kind.valid() {
+			errs = errs.add(fieldPrefix+".kind", "must be decoration, image, or font")
+		}
+		if strings.TrimSpace(asset.Path) == "" {
+			errs = errs.add(fieldPrefix+".path", "is required")
+		}
+	}
+
+	return errs.err()
+}
+
+func (s PageSize) valid() bool {
+	switch s {
+	case PageSizeA3, PageSizeA4, PageSizeA5, PageSizeA6:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o Orientation) valid() bool {
+	switch o {
+	case OrientationPortrait, OrientationLandscape:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f ExportFormat) valid() bool {
+	switch f {
+	case ExportFormatPDF, ExportFormatPNG, ExportFormatSVG:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t SlotType) valid() bool {
+	switch t {
+	case SlotTypeText, SlotTypeImage, SlotTypeDecoration:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a TextAlign) valid() bool {
+	switch a {
+	case TextAlignLeft, TextAlignCenter, TextAlignRight:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o OverflowMode) valid() bool {
+	switch o {
+	case OverflowModeClip, OverflowModeTruncate, OverflowModeError:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f FitMode) valid() bool {
+	switch f {
+	case FitModeContain, FitModeCover:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a AssetKind) valid() bool {
+	switch a {
+	case AssetKindDecoration, AssetKindImage, AssetKindFont:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -1,0 +1,55 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectValidateReportsMissingFields(t *testing.T) {
+	project := Project{}
+
+	err := project.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	for _, fragment := range []string{
+		"version: must be 1",
+		"template: is required",
+		"page.size",
+		"page.orientation",
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("expected %q in validation error, got %q", fragment, err.Error())
+		}
+	}
+}
+
+func TestTemplateValidateReportsStyleReferenceErrors(t *testing.T) {
+	template := Template{
+		Version: CurrentSchemaVersion,
+		ID:      "classic-letter",
+		Page: TemplatePage{
+			SupportedSizes:     []PageSize{PageSizeA4},
+			DefaultOrientation: OrientationPortrait,
+		},
+		Slots: []Slot{
+			{
+				ID:    "body",
+				Type:  SlotTypeText,
+				WMM:   100,
+				HMM:   80,
+				Style: "missing-style",
+			},
+		},
+	}
+
+	err := template.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if !strings.Contains(err.Error(), "slots[0].style: must reference a defined style") {
+		t.Fatalf("expected missing style validation error, got %q", err.Error())
+	}
+}

--- a/internal/schema/loader.go
+++ b/internal/schema/loader.go
@@ -1,0 +1,59 @@
+package schema
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"gopkg.in/yaml.v3"
+)
+
+func ParseProject(data []byte) (domain.Project, error) {
+	var project domain.Project
+	if err := decodeStrict("project", data, &project); err != nil {
+		return domain.Project{}, err
+	}
+	if err := project.Validate(); err != nil {
+		return domain.Project{}, fmt.Errorf("validate project YAML: %w", err)
+	}
+	return project, nil
+}
+
+func ParseTemplate(data []byte) (domain.Template, error) {
+	var template domain.Template
+	if err := decodeStrict("template", data, &template); err != nil {
+		return domain.Template{}, err
+	}
+	if err := template.Validate(); err != nil {
+		return domain.Template{}, fmt.Errorf("validate template YAML: %w", err)
+	}
+	return template, nil
+}
+
+func LoadProjectFile(path string) (domain.Project, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return domain.Project{}, fmt.Errorf("read project YAML: %w", err)
+	}
+	return ParseProject(data)
+}
+
+func LoadTemplateFile(path string) (domain.Template, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return domain.Template{}, fmt.Errorf("read template YAML: %w", err)
+	}
+	return ParseTemplate(data)
+}
+
+func decodeStrict(kind string, data []byte, out any) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	if err := decoder.Decode(out); err != nil {
+		return fmt.Errorf("decode %s YAML: %w", kind, err)
+	}
+
+	return nil
+}

--- a/internal/schema/loader_test.go
+++ b/internal/schema/loader_test.go
@@ -1,0 +1,137 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+func TestParseProjectValidYAML(t *testing.T) {
+	project, err := ParseProject([]byte(`
+version: 1
+template: classic-letter-a4
+page:
+  size: A4
+  orientation: portrait
+content:
+  title: For You
+  body: Thank you for everything.
+  signature: Jaeyoung
+images:
+  - slot: photo1
+    path: ./assets/photo.jpg
+export:
+  format: pdf
+`))
+	if err != nil {
+		t.Fatalf("expected project YAML to parse, got %v", err)
+	}
+
+	if project.Version != domain.CurrentSchemaVersion {
+		t.Fatalf("expected schema version %d, got %d", domain.CurrentSchemaVersion, project.Version)
+	}
+	if project.Page.Size != domain.PageSizeA4 {
+		t.Fatalf("expected page size A4, got %q", project.Page.Size)
+	}
+	if project.Export.Format != domain.ExportFormatPDF {
+		t.Fatalf("expected export format pdf, got %q", project.Export.Format)
+	}
+}
+
+func TestParseTemplateValidYAML(t *testing.T) {
+	template, err := ParseTemplate([]byte(`
+version: 1
+id: classic-letter-a4
+page:
+  supported_sizes: [A4, A5]
+  default_orientation: portrait
+layout:
+  margin_mm: 14
+slots:
+  - id: title
+    type: text
+    x_mm: 20
+    y_mm: 20
+    w_mm: 170
+    h_mm: 20
+    style: title
+  - id: body
+    type: text
+    x_mm: 20
+    y_mm: 48
+    w_mm: 170
+    h_mm: 180
+    style: body
+styles:
+  title:
+    font: SerifDisplay
+    size_pt: 22
+    align: center
+  body:
+    font: SansBody
+    size_pt: 11
+    line_height: 1.4
+assets:
+  - id: floral-corner
+    kind: decoration
+    path: ./assets/floral-corner.svg
+`))
+	if err != nil {
+		t.Fatalf("expected template YAML to parse, got %v", err)
+	}
+
+	if template.ID != "classic-letter-a4" {
+		t.Fatalf("expected template id classic-letter-a4, got %q", template.ID)
+	}
+	if len(template.Slots) != 2 {
+		t.Fatalf("expected 2 slots, got %d", len(template.Slots))
+	}
+}
+
+func TestParseProjectRejectsUnknownFields(t *testing.T) {
+	_, err := ParseProject([]byte(`
+version: 1
+template: classic-letter-a4
+page:
+  size: A4
+  orientation: portrait
+bogus: true
+`))
+	if err == nil {
+		t.Fatal("expected strict YAML decode error")
+	}
+
+	if !strings.Contains(err.Error(), "decode project YAML") || !strings.Contains(err.Error(), "field bogus not found") {
+		t.Fatalf("expected strict decode error, got %q", err.Error())
+	}
+}
+
+func TestParseTemplateRejectsValidationErrors(t *testing.T) {
+	_, err := ParseTemplate([]byte(`
+version: 1
+id: invalid-template
+page:
+  supported_sizes: [A4]
+  default_orientation: portrait
+slots:
+  - id: body
+    type: text
+    x_mm: 10
+    y_mm: 10
+    w_mm: 100
+    h_mm: 80
+    style: body
+styles:
+  body:
+    font: SansBody
+    size_pt: 0
+`))
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if !strings.Contains(err.Error(), "validate template YAML") || !strings.Contains(err.Error(), "styles.body.size_pt") {
+		t.Fatalf("expected validation error details, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add shared domain types for project and template schema v1
- add strict YAML parsing and file-loading helpers under `internal/schema`
- add validation and parsing tests for valid, invalid, and unknown-field cases

## Testing
- `make test`

Refs #2
