### PR TITLE
Add ISO page geometry helpers

### DIFF
--- a/internal/domain/geometry.go
+++ b/internal/domain/geometry.go
@@ -1,0 +1,36 @@
+package domain
+
+import "fmt"
+
+// Millimetres is the shared measurement unit for page and layout dimensions.
+type Millimetres float64
+
+// Dimensions captures width and height in millimetres.
+type Dimensions struct {
+	WidthMM  Millimetres
+	HeightMM Millimetres
+}
+
+var isoPageSizes = map[PageSize]Dimensions{
+	PageSizeA3: {WidthMM: 297, HeightMM: 420},
+	PageSizeA4: {WidthMM: 210, HeightMM: 297},
+	PageSizeA5: {WidthMM: 148, HeightMM: 210},
+	PageSizeA6: {WidthMM: 105, HeightMM: 148},
+}
+
+// ISOPage returns the page dimensions in millimetres for the given size and orientation.
+func ISOPage(size PageSize, orientation Orientation) (Dimensions, error) {
+	base, ok := isoPageSizes[size]
+	if !ok {
+		return Dimensions{}, fmt.Errorf("unsupported page size: %s", size)
+	}
+
+	switch orientation {
+	case OrientationPortrait:
+		return base, nil
+	case OrientationLandscape:
+		return Dimensions{WidthMM: base.HeightMM, HeightMM: base.WidthMM}, nil
+	default:
+		return Dimensions{}, fmt.Errorf("unsupported orientation: %s", orientation)
+	}
+}

--- a/internal/domain/geometry_test.go
+++ b/internal/domain/geometry_test.go
@@ -1,0 +1,58 @@
+package domain
+
+import "testing"
+
+func TestISOPagePortraitAndLandscape(t *testing.T) {
+	tests := []struct {
+		name      string
+		size      PageSize
+		portrait  Dimensions
+		landscape Dimensions
+	}{
+		{
+			name:      "A3",
+			size:      PageSizeA3,
+			portrait:  Dimensions{WidthMM: 297, HeightMM: 420},
+			landscape: Dimensions{WidthMM: 420, HeightMM: 297},
+		},
+		{
+			name:      "A4",
+			size:      PageSizeA4,
+			portrait:  Dimensions{WidthMM: 210, HeightMM: 297},
+			landscape: Dimensions{WidthMM: 297, HeightMM: 210},
+		},
+		{
+			name:      "A5",
+			size:      PageSizeA5,
+			portrait:  Dimensions{WidthMM: 148, HeightMM: 210},
+			landscape: Dimensions{WidthMM: 210, HeightMM: 148},
+		},
+		{
+			name:      "A6",
+			size:      PageSizeA6,
+			portrait:  Dimensions{WidthMM: 105, HeightMM: 148},
+			landscape: Dimensions{WidthMM: 148, HeightMM: 105},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"Portrait", func(t *testing.T) {
+			got, err := ISOPage(tt.size, OrientationPortrait)
+			if err != nil {
+				t.Fatalf("ISOPage(..., Portrait) returned error: %v", err)
+			}
+			if got != tt.portrait {
+				t.Fatalf("ISOPage(..., Portrait) = %#v, want %#v", got, tt.portrait)
+			}
+		})
+		t.Run(tt.name+"Landscape", func(t *testing.T) {
+			got, err := ISOPage(tt.size, OrientationLandscape)
+			if err != nil {
+				t.Fatalf("ISOPage(..., Landscape) returned error: %v", err)
+			}
+			if got != tt.landscape {
+				t.Fatalf("ISOPage(..., Landscape) = %#v, want %#v", got, tt.landscape)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add ISO page dimensions helpers and measurement primitives to domain
- cover portrait/landscape dimensions for A3 through A6 with tests

## Testing
- make test (failsafe gating)
- verify portrait/landscape dimensions for A3/A4/A5/A6 are correct

Closes #12