### PR TITLE
Add Bubble Tea shell and keymap

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,18 +7,117 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// Model is the minimal Bubble Tea shell for the initial bootstrap issue.
+type Step string
+
+const (
+	StepTemplate Step = "Template Selection"
+	StepSize     Step = "Paper Size & Orientation"
+	StepContent  Step = "Content Composition"
+	StepReview   Step = "Review & Export"
+)
+
+var stepOrder = []Step{
+	StepTemplate,
+	StepSize,
+	StepContent,
+	StepReview,
+}
+
+type RouteState struct {
+	Title       string
+	Description string
+	Placeholder string
+}
+
+type State struct {
+	Current Step
+	Routes  map[Step]RouteState
+}
+
+func newState() State {
+	return State{
+		Current: StepTemplate,
+		Routes: map[Step]RouteState{
+			StepTemplate: {
+				Title:       "Template Selection",
+				Description: "Placeholder route for curated templates and layouts.",
+				Placeholder: "Future work: list letter, card, and note templates.",
+			},
+			StepSize: {
+				Title:       "Paper Size & Orientation",
+				Description: "Frame the composition for A3–A6 in portrait or landscape.",
+				Placeholder: "Future work: preview mm dimensions and safe margins.",
+			},
+			StepContent: {
+				Title:       "Content Composition",
+				Description: "Compose title, body, signature, and decorative slots.",
+				Placeholder: "Future work: edit text slots and attach optional assets.",
+			},
+			StepReview: {
+				Title:       "Review & Export",
+				Description: "Finalize layout, toggle decorations, and export.",
+				Placeholder: "Future work: show export targets (PDF/PNG) and notes.",
+			},
+		},
+	}
+}
+
+func (s State) currentIndex() int {
+	for i, step := range stepOrder {
+		if step == s.Current {
+			return i
+		}
+	}
+
+	return 0
+}
+
+func (s State) withNext() State {
+	idx := s.currentIndex()
+	if idx+1 < len(stepOrder) {
+		s.Current = stepOrder[idx+1]
+	}
+
+	return s
+}
+
+func (s State) withPrev() State {
+	idx := s.currentIndex()
+	if idx > 0 {
+		s.Current = stepOrder[idx-1]
+	}
+
+	return s
+}
+
+type KeyMap struct {
+	Forward string
+	Back    string
+	Quit    string
+}
+
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Forward: "enter / right / down",
+		Back:    "backspace / left / up",
+		Quit:    "q / ctrl+c",
+	}
+}
+
 type Model struct {
+	state  State
+	keyMap KeyMap
 	width  int
 	height int
 }
 
-// NewModel creates the initial TUI model.
 func NewModel() Model {
-	return Model{}
+	return Model{
+		state:  newState(),
+		keyMap: DefaultKeyMap(),
+	}
 }
 
-// Run launches the Bubble Tea program.
 func Run() error {
 	program := tea.NewProgram(NewModel(), tea.WithAltScreen())
 	_, err := program.Run()
@@ -38,6 +137,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
+		case "enter", "right", "down", " ":
+			m.state = m.state.withNext()
+		case "left", "up", "backspace", "esc":
+			m.state = m.state.withPrev()
 		}
 	}
 
@@ -47,22 +150,43 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	lines := []string{
 		"letterpress",
+		"Bubble Tea composition shell",
 		"",
-		"Terminal-first letter and card composer",
+		m.renderSteps(),
 		"",
-		"Bootstrap workflow",
-		"1. Template selection",
-		"2. Page size and orientation",
-		"3. Content composition",
-		"4. Review and export",
+		m.renderRoute(),
 		"",
-		"Press q to quit.",
-	}
-
-	if m.width > 0 || m.height > 0 {
-		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("Viewport: %dx%d", m.width, m.height))
+		fmt.Sprintf("Viewport: %dx%d", m.width, m.height),
+		"",
+		m.renderKeyLegend(),
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderSteps() string {
+	var steps []string
+	steps = append(steps, "Steps:")
+	for _, step := range stepOrder {
+		prefix := "   "
+		if step == m.state.Current {
+			prefix = "→ "
+		}
+		steps = append(steps, fmt.Sprintf("%s%s", prefix, step))
+	}
+
+	return strings.Join(steps, "\n")
+}
+
+func (m Model) renderRoute() string {
+	route, ok := m.state.Routes[m.state.Current]
+	if !ok {
+		return "Route placeholder unavailable."
+	}
+
+	return fmt.Sprintf("%s\n%s\n\n%s", route.Title, route.Description, route.Placeholder)
+}
+
+func (m Model) renderKeyLegend() string {
+	return fmt.Sprintf("[Forward: %s]  [Back: %s]  [Quit: %s]", m.keyMap.Forward, m.keyMap.Back, m.keyMap.Quit)
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -5,17 +5,45 @@ import (
 	"testing"
 )
 
-func TestViewIncludesBootstrapWorkflow(t *testing.T) {
+func TestViewShowsShellLayout(t *testing.T) {
 	view := NewModel().View()
 
 	for _, fragment := range []string{
 		"letterpress",
-		"Bootstrap workflow",
-		"Template selection",
-		"Press q to quit.",
+		"Bubble Tea composition shell",
+		"Steps:",
+		"Template Selection",
+		"Review & Export",
+		"[Forward:",
+		"[Back:",
+		"[Quit:",
 	} {
 		if !strings.Contains(view, fragment) {
 			t.Fatalf("expected view to contain %q, got %q", fragment, view)
 		}
+	}
+}
+
+func TestStateAdvancesAndRewinds(t *testing.T) {
+	model := NewModel()
+	initialView := model.View()
+
+	model.state = model.state.withNext()
+	if model.state.Current != StepSize {
+		t.Fatalf("expected step %q after forward, got %q", StepSize, model.state.Current)
+	}
+
+	interstitialView := model.View()
+	if interstitialView == initialView {
+		t.Fatalf("expected view to change after a forward step")
+	}
+
+	model.state = model.state.withPrev()
+	if model.state.Current != StepTemplate {
+		t.Fatalf("expected step %q after back, got %q", StepTemplate, model.state.Current)
+	}
+
+	if model.View() != initialView {
+		t.Fatalf("expected view to return to the initial state after rewinding")
 	}
 }


### PR DESCRIPTION
## Summary\n- replace the bootstrap view with a step-based shell, placeholder routes, and the Step/State/KeyMap contracts\n- keep navigation limited to forward/back/quit while the frames remain placeholders for future form logic\n\nCloses #15\n\n## Testing\n- go test ./...