### PR TITLE
Add project save/load YAML persistence

### DIFF
--- a/internal/projectio/projectio.go
+++ b/internal/projectio/projectio.go
@@ -1,0 +1,62 @@
+package projectio
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads a v1 YAML project file, validates it, and returns the parsed Project.
+func Load(path string) (domain.Project, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return domain.Project{}, fmt.Errorf("read project file %q: %w", path, err)
+	}
+
+	var project domain.Project
+	if err := yaml.Unmarshal(data, &project); err != nil {
+		return domain.Project{}, fmt.Errorf("parse project YAML %q: %w", path, err)
+	}
+
+	if err := project.Validate(); err != nil {
+		return domain.Project{}, fmt.Errorf("validate project %q: %w", path, err)
+	}
+
+	return project, nil
+}
+
+// Save validates the project and writes it as YAML to the provided path.
+func Save(path string, project domain.Project) error {
+	if err := project.Validate(); err != nil {
+		return fmt.Errorf("validate project before save: %w", err)
+	}
+
+	data, err := yaml.Marshal(project)
+	if err != nil {
+		return fmt.Errorf("serialize project: %w", err)
+	}
+
+	if err := ensureDirectory(path); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write project file %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func ensureDirectory(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("prepare directory %q: %w", dir, err)
+	}
+	return nil
+}

--- a/internal/projectio/projectio_test.go
+++ b/internal/projectio/projectio_test.go
@@ -1,0 +1,85 @@
+package projectio
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+func sampleProject() domain.Project {
+	return domain.Project{
+		Version:  domain.CurrentSchemaVersion,
+		Template: "classic-letter-a4",
+		Page: domain.ProjectPage{
+			Size:        domain.PageSizeA4,
+			Orientation: domain.OrientationPortrait,
+		},
+		Content: domain.Content{
+			Title:     "Hello",
+			Body:      "Thanks for being amazing.",
+			Signature: "Jane",
+		},
+		Images: []domain.ImageBinding{
+			{Slot: "photo", Path: "assets/photo.jpg"},
+		},
+		Options: domain.ProjectOptions{
+			Decorations: true,
+		},
+		Export: domain.ExportOptions{
+			Format: domain.ExportFormatPDF,
+			Out:    "out/card.pdf",
+		},
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "nested", "project.yaml")
+
+	project := sampleProject()
+	if err := Save(path, project); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(project, loaded) {
+		t.Fatalf("loaded project differs from saved project: got %+v want %+v", loaded, project)
+	}
+}
+
+func TestSaveRejectsInvalidProject(t *testing.T) {
+	err := Save(filepath.Join(t.TempDir(), "bad.yaml"), domain.Project{})
+	if err == nil {
+		t.Fatal("expected validation error from Save()")
+	}
+	var ve domain.ValidationErrors
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected ValidationErrors, got %T: %v", err, err)
+	}
+}
+
+func TestLoadRejectsInvalidProject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.yaml")
+	data := []byte("version: 1\npage:\n  size: A4\n  orientation: portrait\n")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("Write invalid project: %v", err)
+	}
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected validation error from Load()")
+	} else {
+		var ve domain.ValidationErrors
+		if !errors.As(err, &ve) {
+			t.Fatalf("expected ValidationErrors, got %T: %v", err, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add internal/projectio package with YAML load/save helpers and validation-aware errors
- add regression tests that cover round-trip persistence and validation failures

## Testing
- go test ./...

Closes #19