### PR TITLE
Integrate TUI composition state

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -105,16 +105,18 @@ func DefaultKeyMap() KeyMap {
 }
 
 type Model struct {
-	state  State
-	keyMap KeyMap
-	width  int
-	height int
+	state       State
+	composition CompositionState
+	keyMap      KeyMap
+	width       int
+	height      int
 }
 
 func NewModel() Model {
 	return Model{
-		state:  newState(),
-		keyMap: DefaultKeyMap(),
+		state:       newState(),
+		composition: newCompositionState(),
+		keyMap:      DefaultKeyMap(),
 	}
 }
 
@@ -156,6 +158,8 @@ func (m Model) View() string {
 		"",
 		m.renderRoute(),
 		"",
+		m.renderCompositionSummary(),
+		"",
 		fmt.Sprintf("Viewport: %dx%d", m.width, m.height),
 		"",
 		m.renderKeyLegend(),
@@ -185,6 +189,10 @@ func (m Model) renderRoute() string {
 	}
 
 	return fmt.Sprintf("%s\n%s\n\n%s", route.Title, route.Description, route.Placeholder)
+}
+
+func (m Model) renderCompositionSummary() string {
+	return fmt.Sprintf("Composition in progress (%s)", m.composition.Summary())
 }
 
 func (m Model) renderKeyLegend() string {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -17,6 +17,7 @@ func TestViewShowsShellLayout(t *testing.T) {
 		"[Forward:",
 		"[Back:",
 		"[Quit:",
+		"Composition in progress",
 	} {
 		if !strings.Contains(view, fragment) {
 			t.Fatalf("expected view to contain %q, got %q", fragment, view)
@@ -27,6 +28,7 @@ func TestViewShowsShellLayout(t *testing.T) {
 func TestStateAdvancesAndRewinds(t *testing.T) {
 	model := NewModel()
 	initialView := model.View()
+	initialSummary := model.composition.Summary()
 
 	model.state = model.state.withNext()
 	if model.state.Current != StepSize {
@@ -45,5 +47,9 @@ func TestStateAdvancesAndRewinds(t *testing.T) {
 
 	if model.View() != initialView {
 		t.Fatalf("expected view to return to the initial state after rewinding")
+	}
+
+	if model.composition.Summary() != initialSummary {
+		t.Fatalf("composition summary changed after navigation: before=%q after=%q", initialSummary, model.composition.Summary())
 	}
 }

--- a/internal/tui/composition.go
+++ b/internal/tui/composition.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"fmt"
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+type CompositionState struct {
+	Project domain.Project
+}
+
+func newCompositionState() CompositionState {
+	return CompositionState{
+		Project: domain.Project{
+			Version:  domain.CurrentSchemaVersion,
+			Template: "classic-letter-a4",
+			Page: domain.ProjectPage{
+				Size:        domain.PageSizeA4,
+				Orientation: domain.OrientationPortrait,
+			},
+			Content: domain.Content{},
+			Images:  nil,
+			Options: domain.ProjectOptions{
+				Decorations: true,
+			},
+			Export: domain.ExportOptions{
+				Format: domain.ExportFormatPDF,
+			},
+		},
+	}
+}
+
+func (c CompositionState) Summary() string {
+	project := c.Project
+	return fmt.Sprintf("template=%s size=%s orientation=%s", project.Template, project.Page.Size, project.Page.Orientation)
+}


### PR DESCRIPTION
## Summary\n- introduce a domain-backed CompositionState so the shell holds project/template options while the UI stays placeholder-only\n- keep the existing step ordering and placeholder route text while surfacing a summary of the current composition\n- add a regression test showing navigation preserves the shared state summary\n\nCloses #16\n\n## Testing\n- go test ./...