### PR TITLE
Implement template resolution

### DIFF
--- a/internal/template/resolve.go
+++ b/internal/template/resolve.go
@@ -1,0 +1,175 @@
+package template
+
+import (
+	"fmt"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+// ResolvedTemplate represents a template merged with a project instance.
+type ResolvedTemplate struct {
+	TemplateID   string
+	Layout       domain.Layout
+	TemplatePage domain.TemplatePage
+	ProjectPage  domain.ProjectPage
+	Slots        []ResolvedSlot
+	Styles       map[string]domain.Style
+	Assets       map[string]domain.Asset
+}
+
+// ResolvedSlot carries template slot metadata together with resolved content bindings.
+type ResolvedSlot struct {
+	Slot       domain.Slot
+	Style      *domain.Style
+	Text       string
+	ImagePath  string
+	Decoration *domain.Asset
+}
+
+// Resolve materializes a template and project pairing into concrete slot data for rendering.
+func Resolve(template domain.Template, project domain.Project) (ResolvedTemplate, error) {
+	pageSize, err := resolvePageSize(template, project)
+	if err != nil {
+		return ResolvedTemplate{}, err
+	}
+
+	orientation, err := resolveOrientation(template, project)
+	if err != nil {
+		return ResolvedTemplate{}, err
+	}
+
+	assets := make(map[string]domain.Asset, len(template.Assets))
+	for _, asset := range template.Assets {
+		assets[asset.ID] = asset
+	}
+
+	slots := make([]ResolvedSlot, 0, len(template.Slots))
+	for _, slot := range template.Slots {
+		resolved, err := resolveSlot(slot, template.Styles, assets, project.Content, project.Images)
+		if err != nil {
+			return ResolvedTemplate{}, err
+		}
+		slots = append(slots, resolved)
+	}
+
+	resolved := ResolvedTemplate{
+		TemplateID:   template.ID,
+		Layout:       template.Layout,
+		TemplatePage: template.Page,
+		ProjectPage: domain.ProjectPage{
+			Size:        pageSize,
+			Orientation: orientation,
+		},
+		Slots:  slots,
+		Styles: template.Styles,
+		Assets: assets,
+	}
+
+	return resolved, nil
+}
+
+func resolveSlot(slot domain.Slot, styles map[string]domain.Style, assets map[string]domain.Asset, content domain.Content, images []domain.ImageBinding) (ResolvedSlot, error) {
+	resolved := ResolvedSlot{Slot: slot}
+
+	if slot.Style != "" {
+		if style, ok := styles[slot.Style]; ok {
+			copy := style
+			resolved.Style = &copy
+		}
+	}
+
+	switch slot.Type {
+	case domain.SlotTypeText:
+		resolved.Text = resolveTextContent(content, slot.ID)
+		if slot.Required && resolved.Text == "" {
+			return ResolvedSlot{}, fmt.Errorf("required text slot %s is empty", slot.ID)
+		}
+	case domain.SlotTypeImage:
+		path, ok := findImageBinding(images, slot.ID)
+		if slot.Required && !ok {
+			return ResolvedSlot{}, fmt.Errorf("required image slot %s is missing a binding", slot.ID)
+		}
+		resolved.ImagePath = path
+	case domain.SlotTypeDecoration:
+		asset, ok := assets[slot.ID]
+		if slot.Required && !ok {
+			return ResolvedSlot{}, fmt.Errorf("required decoration slot %s lacks an asset", slot.ID)
+		}
+		if ok {
+			copy := asset
+			resolved.Decoration = &copy
+		}
+	default:
+		return ResolvedSlot{}, fmt.Errorf("unsupported slot type %s", slot.Type)
+	}
+
+	return resolved, nil
+}
+
+func resolvePageSize(template domain.Template, project domain.Project) (domain.PageSize, error) {
+	if len(template.Page.SupportedSizes) == 0 {
+		return "", fmt.Errorf("template %s defines no supported page sizes", template.ID)
+	}
+
+	size := project.Page.Size
+	if size == "" {
+		size = template.Page.SupportedSizes[0]
+	}
+
+	if !containsSize(template.Page.SupportedSizes, size) {
+		return "", fmt.Errorf("template %s does not support page size %s", template.ID, size)
+	}
+
+	return size, nil
+}
+
+func resolveOrientation(template domain.Template, project domain.Project) (domain.Orientation, error) {
+	orientation := project.Page.Orientation
+	if orientation == "" {
+		orientation = template.Page.DefaultOrientation
+	}
+	if orientation == "" {
+		orientation = domain.OrientationPortrait
+	}
+
+	if !isValidOrientation(orientation) {
+		return "", fmt.Errorf("invalid orientation %s", orientation)
+	}
+
+	return orientation, nil
+}
+
+func containsSize(sizes []domain.PageSize, size domain.PageSize) bool {
+	for _, candidate := range sizes {
+		if candidate == size {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidOrientation(value domain.Orientation) bool {
+	return value == domain.OrientationPortrait || value == domain.OrientationLandscape
+}
+
+func resolveTextContent(content domain.Content, slotID string) string {
+	switch slotID {
+	case "title":
+		return content.Title
+	case "body":
+		return content.Body
+	case "signature":
+		return content.Signature
+	default:
+		return ""
+	}
+}
+
+func findImageBinding(bindings []domain.ImageBinding, slotID string) (string, bool) {
+	for _, binding := range bindings {
+		if binding.Slot == slotID {
+			return binding.Path, true
+		}
+	}
+	return "", false
+}

--- a/internal/template/resolve.go
+++ b/internal/template/resolve.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jaeyoung0509/letterpress/internal/domain"
 )
@@ -153,12 +154,12 @@ func isValidOrientation(value domain.Orientation) bool {
 }
 
 func resolveTextContent(content domain.Content, slotID string) string {
-	switch slotID {
-	case "title":
+	switch strings.ToLower(strings.TrimSpace(slotID)) {
+	case "title", "heading", "headline", "greeting":
 		return content.Title
-	case "body":
+	case "body", "message", "note":
 		return content.Body
-	case "signature":
+	case "signature", "signoff", "closing":
 		return content.Signature
 	default:
 		return ""

--- a/internal/template/resolve_test.go
+++ b/internal/template/resolve_test.go
@@ -1,0 +1,108 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+func TestResolveTemplateProducesExpectedSlotData(t *testing.T) {
+	template := domain.Template{
+		ID: "classic-letter",
+		Page: domain.TemplatePage{
+			SupportedSizes:     []domain.PageSize{domain.PageSizeA4},
+			DefaultOrientation: domain.OrientationPortrait,
+		},
+		Layout: domain.Layout{MarginMM: 12},
+		Styles: map[string]domain.Style{
+			"title": {Font: "SerifDisplay", SizePt: 24},
+			"body":  {Font: "SansBody", SizePt: 12},
+		},
+		Slots: []domain.Slot{
+			{ID: "title", Type: domain.SlotTypeText, Style: "title", XMM: 20, YMM: 20, WMM: 170, HMM: 30, Required: true},
+			{ID: "body", Type: domain.SlotTypeText, Style: "body", XMM: 20, YMM: 60, WMM: 170, HMM: 150},
+			{ID: "photo", Type: domain.SlotTypeImage, XMM: 20, YMM: 220, WMM: 80, HMM: 80, Required: true},
+			{ID: "ornament", Type: domain.SlotTypeDecoration},
+		},
+		Assets: []domain.Asset{
+			{ID: "ornament", Kind: domain.AssetKindDecoration, Path: "assets/floral.png"},
+		},
+	}
+
+	project := domain.Project{
+		Version:  domain.CurrentSchemaVersion,
+		Template: template.ID,
+		Page: domain.ProjectPage{
+			Size:        domain.PageSizeA4,
+			Orientation: domain.OrientationPortrait,
+		},
+		Content: domain.Content{
+			Title: "Happy Birthday",
+			Body:  "Wishing you a lovely day of letters and tea.",
+		},
+		Images: []domain.ImageBinding{
+			{Slot: "photo", Path: "images/hero.png"},
+		},
+	}
+
+	resolved, err := Resolve(template, project)
+	if err != nil {
+		t.Fatalf("Resolve returned an error: %v", err)
+	}
+	if resolved.TemplateID != template.ID {
+		t.Fatalf("resolved TemplateID = %s, want %s", resolved.TemplateID, template.ID)
+	}
+	if resolved.ProjectPage != project.Page {
+		t.Fatalf("resolved ProjectPage = %+v, want %+v", resolved.ProjectPage, project.Page)
+	}
+
+	slots := mapSlots(resolved.Slots)
+	if slots["title"].Text != project.Content.Title {
+		t.Fatalf("title slot text = %q, want %q", slots["title"].Text, project.Content.Title)
+	}
+	if slots["title"].Style == nil || slots["title"].Style.Font != template.Styles["title"].Font {
+		t.Fatalf("title slot style not wired correctly")
+	}
+	if slots["photo"].ImagePath != "images/hero.png" {
+		t.Fatalf("photo slot path = %q, want %q", slots["photo"].ImagePath, "images/hero.png")
+	}
+	if slots["ornament"].Decoration == nil || slots["ornament"].Decoration.Path != "assets/floral.png" {
+		t.Fatalf("ornament decoration not resolved")
+	}
+}
+
+func TestResolveTemplateMissingRequiredImage(t *testing.T) {
+	template := domain.Template{
+		ID: "hero-card",
+		Page: domain.TemplatePage{
+			SupportedSizes: []domain.PageSize{domain.PageSizeA4},
+		},
+		Slots: []domain.Slot{
+			{ID: "hero", Type: domain.SlotTypeImage, Required: true},
+		},
+	}
+
+	project := domain.Project{
+		Version:  domain.CurrentSchemaVersion,
+		Template: template.ID,
+		Page: domain.ProjectPage{
+			Size:        domain.PageSizeA4,
+			Orientation: domain.OrientationPortrait,
+		},
+	}
+
+	if _, err := Resolve(template, project); err == nil {
+		t.Fatal("expected Resolve to fail when an image slot is required but missing")
+	} else if !strings.Contains(err.Error(), "hero") {
+		t.Fatalf("error message = %q, want it to mention the slot ID", err)
+	}
+}
+
+func mapSlots(slots []ResolvedSlot) map[string]ResolvedSlot {
+	result := make(map[string]ResolvedSlot, len(slots))
+	for _, slot := range slots {
+		result[slot.Slot.ID] = slot
+	}
+	return result
+}

--- a/internal/template/resolve_test.go
+++ b/internal/template/resolve_test.go
@@ -99,6 +99,50 @@ func TestResolveTemplateMissingRequiredImage(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateSupportsCommonTextSlotAliases(t *testing.T) {
+	template := domain.Template{
+		ID: "note-card",
+		Page: domain.TemplatePage{
+			SupportedSizes: []domain.PageSize{domain.PageSizeA6},
+		},
+		Slots: []domain.Slot{
+			{ID: "greeting", Type: domain.SlotTypeText, Required: true},
+			{ID: "note", Type: domain.SlotTypeText, Required: true},
+			{ID: "signoff", Type: domain.SlotTypeText, Required: true},
+		},
+	}
+
+	project := domain.Project{
+		Version:  domain.CurrentSchemaVersion,
+		Template: template.ID,
+		Page: domain.ProjectPage{
+			Size:        domain.PageSizeA6,
+			Orientation: domain.OrientationLandscape,
+		},
+		Content: domain.Content{
+			Title:     "For You",
+			Body:      "A short note that should fill the card body slot.",
+			Signature: "Warmly, Alex",
+		},
+	}
+
+	resolved, err := Resolve(template, project)
+	if err != nil {
+		t.Fatalf("Resolve returned an error: %v", err)
+	}
+
+	slots := mapSlots(resolved.Slots)
+	if slots["greeting"].Text != project.Content.Title {
+		t.Fatalf("greeting slot text = %q, want %q", slots["greeting"].Text, project.Content.Title)
+	}
+	if slots["note"].Text != project.Content.Body {
+		t.Fatalf("note slot text = %q, want %q", slots["note"].Text, project.Content.Body)
+	}
+	if slots["signoff"].Text != project.Content.Signature {
+		t.Fatalf("signoff slot text = %q, want %q", slots["signoff"].Text, project.Content.Signature)
+	}
+}
+
 func mapSlots(slots []ResolvedSlot) map[string]ResolvedSlot {
 	result := make(map[string]ResolvedSlot, len(slots))
 	for _, slot := range slots {


### PR DESCRIPTION
## Summary
- introduce the template resolution contract that produces ResolvedTemplate data for rendering
- map text, image, and decoration slots to project content, bindings, and assets
- add coverage that guarantees slot outputs are deterministic and that required bindings are enforced

## Testing
- make test
- manual check: validated that a sample template/project pair yields the expected slot payloads and asset pointers

Closes #13