### PR TITLE
Add CLI template commands

### DIFF
--- a/cmd/letterpress/root.go
+++ b/cmd/letterpress/root.go
@@ -1,6 +1,7 @@
 package letterpress
 
 import (
+	"github.com/jaeyoung0509/letterpress/internal/cli"
 	"github.com/jaeyoung0509/letterpress/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,8 @@ func NewRootCmd(deps Dependencies) *cobra.Command {
 	}
 
 	cmd.AddCommand(newTUICmd(deps))
+	cmd.AddCommand(cli.NewTemplatesCmd())
+	cmd.AddCommand(cli.NewValidateCmd())
 	return cmd
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTemplatesListCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeSampleTemplate(t, filepath.Join(dir, "letter", "classic-letter.yaml"), "classic-letter")
+	writeSampleTemplate(t, filepath.Join(dir, "card", "modern-card.yaml"), "modern-card")
+
+	cmd := NewTemplatesCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"list", "--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("templates list failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("unexpected output lines: %q", lines)
+	}
+	if !strings.HasPrefix(lines[0], "classic-letter") || !strings.HasPrefix(lines[1], "modern-card") {
+		t.Fatalf("templates not listed in expected order: %v", lines)
+	}
+}
+
+func TestValidateCommand(t *testing.T) {
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "template.yaml")
+	projectPath := filepath.Join(dir, "project.yaml")
+
+	writeSampleTemplate(t, templatePath, "classic-letter")
+	writeSampleProject(t, projectPath, "classic-letter")
+
+	cmd := NewValidateCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--template", templatePath, "--project", projectPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("validate command failed: %v", err)
+	}
+
+	lines := output.String()
+	for _, fragment := range []string{
+		"template classic-letter: valid",
+		"project classic-letter: valid",
+		"template and project resolve successfully",
+	} {
+		if !strings.Contains(lines, fragment) {
+			t.Fatalf("expected output to contain %q, got %q", fragment, lines)
+		}
+	}
+}
+
+func writeSampleTemplate(t *testing.T, path, id string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for template: %v", err)
+	}
+	content := fmt.Sprintf(`version: 1
+id: %s
+page:
+  supported_sizes: [A4]
+  default_orientation: portrait
+layout:
+  margin_mm: 12
+slots:
+  - id: title
+    type: text
+    x_mm: 10
+    y_mm: 20
+    w_mm: 160
+    h_mm: 30
+`, id)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+}
+
+func writeSampleProject(t *testing.T, path, templateID string) {
+	t.Helper()
+	content := fmt.Sprintf(`version: 1
+template: %s
+page:
+  size: A4
+  orientation: portrait
+content:
+  title: Hello
+`, templateID)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+}

--- a/internal/cli/templates.go
+++ b/internal/cli/templates.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jaeyoung0509/letterpress/internal/schema"
+)
+
+const defaultTemplateDir = "templates"
+
+type templateEntry struct {
+	ID   string
+	Path string
+}
+
+// NewTemplatesCmd returns the command group for template-related utilities.
+func NewTemplatesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "templates",
+		Short: "Work with shipped templates",
+	}
+	cmd.AddCommand(newTemplatesListCmd())
+	return cmd
+}
+
+func newTemplatesListCmd() *cobra.Command {
+	var dir string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List available templates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			targetDir := dir
+			if targetDir == "" {
+				targetDir = defaultTemplateDir
+			}
+			return runTemplatesList(cmd.OutOrStdout(), targetDir)
+		},
+	}
+	cmd.Flags().StringVar(&dir, "dir", defaultTemplateDir, "template root directory")
+	return cmd
+}
+
+func runTemplatesList(out io.Writer, dir string) error {
+	entries, err := scanTemplates(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(out, "no templates found")
+		return nil
+	}
+	for _, entry := range entries {
+		fmt.Fprintf(out, "%s\t%s\n", entry.ID, entry.Path)
+	}
+	return nil
+}
+
+func scanTemplates(dir string) ([]templateEntry, error) {
+	var entries []templateEntry
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "assets", "samples":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !isTemplateFile(path) {
+			return nil
+		}
+		tmpl, err := schema.LoadTemplateFile(path)
+		if err != nil {
+			return fmt.Errorf("parse template %s: %w", path, err)
+		}
+		entries = append(entries, templateEntry{ID: tmpl.ID, Path: path})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].ID < entries[j].ID
+	})
+	return entries, nil
+}
+
+func isTemplateFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"github.com/jaeyoung0509/letterpress/internal/schema"
+	"github.com/jaeyoung0509/letterpress/internal/template"
+)
+
+// NewValidateCmd returns a command that validates templates and projects.
+func NewValidateCmd() *cobra.Command {
+	var templatePath string
+	var projectPath string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate template and project YAML inputs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runValidate(cmd.OutOrStdout(), templatePath, projectPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&templatePath, "template", "", "path to a template YAML file")
+	cmd.Flags().StringVar(&projectPath, "project", "", "path to a project YAML file")
+	return cmd
+}
+
+func runValidate(out io.Writer, templatePath, projectPath string) error {
+	if templatePath == "" && projectPath == "" {
+		return fmt.Errorf("provide at least one of --template or --project")
+	}
+
+	var (
+		tmpl domain.Template
+		proj domain.Project
+		err  error
+	)
+
+	if templatePath != "" {
+		tmpl, err = schema.LoadTemplateFile(templatePath)
+		if err != nil {
+			return fmt.Errorf("validate template: %w", err)
+		}
+		fmt.Fprintf(out, "template %s: valid\n", tmpl.ID)
+	}
+
+	if projectPath != "" {
+		proj, err = schema.LoadProjectFile(projectPath)
+		if err != nil {
+			return fmt.Errorf("validate project: %w", err)
+		}
+		fmt.Fprintf(out, "project %s: valid\n", proj.Template)
+	}
+
+	if templatePath != "" && projectPath != "" {
+		if proj.Template != "" && tmpl.ID != "" && proj.Template != tmpl.ID {
+			return fmt.Errorf("project template %s does not match template ID %s", proj.Template, tmpl.ID)
+		}
+		if _, err := template.Resolve(tmpl, proj); err != nil {
+			return fmt.Errorf("template/project validation failed: %w", err)
+		}
+		fmt.Fprintf(out, "template and project resolve successfully\n")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- add the templates list and validate commands under the root CLI
- scan the template directory with schema parsing and wire the resolve check for projects
- register the commands in cmd/letterpress and cover the flows with CLI tests

## Testing
- make test (fails: internal/tui currently has missing methods so cmd/letterpress does not build)
- go test ./internal/cli
- manual check: go test ./internal/cli exercises the templates list and validate codepaths

Closes #21