### PR TITLE
Add TUI screens for template, size, and text

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jaeyoung0509/letterpress/internal/domain"
 )
 
 type Step string
@@ -34,6 +36,14 @@ type State struct {
 	Routes  map[Step]RouteState
 }
 
+type ContentField int
+
+const (
+	FieldTitle ContentField = iota
+	FieldBody
+	FieldSignature
+)
+
 func newState() State {
 	return State{
 		Current: StepTemplate,
@@ -41,17 +51,17 @@ func newState() State {
 			StepTemplate: {
 				Title:       "Template Selection",
 				Description: "Placeholder route for curated templates and layouts.",
-				Placeholder: "Future work: list letter, card, and note templates.",
+				Placeholder: "Use j/k to pick templates and Enter to continue.",
 			},
 			StepSize: {
 				Title:       "Paper Size & Orientation",
 				Description: "Frame the composition for A3–A6 in portrait or landscape.",
-				Placeholder: "Future work: preview mm dimensions and safe margins.",
+				Placeholder: "Use s to cycle sizes and o to toggle orientation.",
 			},
 			StepContent: {
 				Title:       "Content Composition",
 				Description: "Compose title, body, signature, and decorative slots.",
-				Placeholder: "Future work: edit text slots and attach optional assets.",
+				Placeholder: "Type text, use Tab to switch fields.",
 			},
 			StepReview: {
 				Title:       "Review & Export",
@@ -105,19 +115,30 @@ func DefaultKeyMap() KeyMap {
 }
 
 type Model struct {
-	state       State
-	composition CompositionState
-	keyMap      KeyMap
-	width       int
-	height      int
+	state         State
+	composition   CompositionState
+	keyMap        KeyMap
+	width         int
+	height        int
+	templates     []TemplateEntry
+	templateIndex int
+	contentField  ContentField
 }
 
 func NewModel() Model {
-	return Model{
-		state:       newState(),
-		composition: newCompositionState(),
-		keyMap:      DefaultKeyMap(),
+	model := Model{
+		state:        newState(),
+		composition:  newCompositionState(),
+		keyMap:       DefaultKeyMap(),
+		templates:    loadTemplateEntries(),
+		contentField: FieldTitle,
 	}
+
+	if len(model.templates) > 0 {
+		model = model.selectTemplate(0)
+	}
+
+	return model
 }
 
 func Run() error {
@@ -136,17 +157,73 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			return m, tea.Quit
-		case "enter", "right", "down", " ":
-			m.state = m.state.withNext()
-		case "left", "up", "backspace", "esc":
-			m.state = m.state.withPrev()
-		}
+		return m.handleKey(msg)
 	}
 
 	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "enter", "right", "down", " ":
+		m.state = m.state.withNext()
+		return m, nil
+	case "esc", "left", "up":
+		m.state = m.state.withPrev()
+		return m, nil
+	case "backspace":
+		if m.state.Current == StepContent {
+			m = m.deleteContentRune()
+		} else {
+			m.state = m.state.withPrev()
+		}
+		return m, nil
+	}
+
+	switch m.state.Current {
+	case StepTemplate:
+		m = m.handleTemplateKey(msg)
+	case StepSize:
+		m = m.handleSizeKey(msg)
+	case StepContent:
+		m = m.handleContentKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleTemplateKey(msg tea.KeyMsg) Model {
+	switch strings.ToLower(msg.String()) {
+	case "j":
+		return m.cycleTemplate(1)
+	case "k":
+		return m.cycleTemplate(-1)
+	}
+
+	return m
+}
+
+func (m Model) handleSizeKey(msg tea.KeyMsg) Model {
+	switch strings.ToLower(msg.String()) {
+	case "s":
+		return m.cycleSize(1)
+	case "o":
+		return m.toggleOrientation()
+	}
+
+	return m
+}
+
+func (m Model) handleContentKey(msg tea.KeyMsg) Model {
+	switch msg.Type {
+	case tea.KeyTab:
+		return m.cycleContentField()
+	case tea.KeyRunes:
+		return m.appendContentRunes(msg.Runes)
+	}
+	return m
 }
 
 func (m Model) View() string {
@@ -157,6 +234,8 @@ func (m Model) View() string {
 		m.renderSteps(),
 		"",
 		m.renderRoute(),
+		"",
+		m.renderStepContent(),
 		"",
 		m.renderCompositionSummary(),
 		"",
@@ -197,4 +276,250 @@ func (m Model) renderCompositionSummary() string {
 
 func (m Model) renderKeyLegend() string {
 	return fmt.Sprintf("[Forward: %s]  [Back: %s]  [Quit: %s]", m.keyMap.Forward, m.keyMap.Back, m.keyMap.Quit)
+}
+
+func (m Model) renderStepContent() string {
+	switch m.state.Current {
+	case StepTemplate:
+		return m.renderTemplatePicker()
+	case StepSize:
+		return m.renderSizeSelector()
+	case StepContent:
+		return m.renderContentEditor()
+	default:
+		return ""
+	}
+}
+
+func (m Model) renderTemplatePicker() string {
+	if len(m.templates) == 0 {
+		return "Template catalog unavailable."
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Available templates:")
+	for idx, entry := range m.templates {
+		prefix := "   "
+		if idx == m.templateIndex {
+			prefix = "→ "
+		}
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("%s%s", prefix, entry.Label()))
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("      sizes: %s", m.formatSizes(entry.SupportedSizes)))
+	}
+
+	builder.WriteString("\n\nUse j/k to cycle templates, Enter to continue.")
+	return builder.String()
+}
+
+func (m Model) renderSizeSelector() string {
+	entry, ok := m.currentTemplateEntry()
+	if !ok {
+		return "Select a template to configure page size."
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Supported sizes:")
+	for _, size := range entry.SupportedSizes {
+		prefix := "   "
+		if size == m.composition.Project.Page.Size {
+			prefix = "→ "
+		}
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("%s%s", prefix, size))
+	}
+
+	builder.WriteString("\n\nOrientation: ")
+	builder.WriteString(string(m.composition.Project.Page.Orientation))
+	builder.WriteString("\n\nPress s to cycle sizes, o to toggle orientation.")
+	return builder.String()
+}
+
+func (m Model) renderContentEditor() string {
+	fields := []struct {
+		field ContentField
+		label string
+	}{
+		{FieldTitle, "Title"},
+		{FieldBody, "Body"},
+		{FieldSignature, "Signature"},
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Content fields:")
+	for _, entry := range fields {
+		prefix := "   "
+		if entry.field == m.contentField {
+			prefix = "→ "
+		}
+		value := m.fieldValue(entry.field)
+		if value == "" {
+			value = "(empty)"
+		}
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("%s%s: %s", prefix, entry.label, value))
+	}
+
+	builder.WriteString("\n\nType to edit text, Tab to switch fields.")
+	return builder.String()
+}
+
+func (m Model) formatSizes(sizes []domain.PageSize) string {
+	if len(sizes) == 0 {
+		return "none"
+	}
+
+	parts := make([]string, len(sizes))
+	for i, size := range sizes {
+		parts[i] = string(size)
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func (m Model) currentTemplateEntry() (TemplateEntry, bool) {
+	if len(m.templates) == 0 {
+		return TemplateEntry{}, false
+	}
+
+	idx := m.templateIndex
+	if idx < 0 || idx >= len(m.templates) {
+		idx = 0
+	}
+
+	return m.templates[idx], true
+}
+
+func (m Model) selectTemplate(idx int) Model {
+	if len(m.templates) == 0 {
+		return m
+	}
+
+	if idx < 0 {
+		idx = 0
+	} else if idx >= len(m.templates) {
+		idx = len(m.templates) - 1
+	}
+
+	entry := m.templates[idx]
+	m.templateIndex = idx
+	m.composition.Project.Template = entry.ID
+	if len(entry.SupportedSizes) > 0 {
+		m.composition.Project.Page.Size = entry.SupportedSizes[0]
+	}
+	m.composition.Project.Page.Orientation = entry.DefaultOrientation
+
+	return m
+}
+
+func (m Model) cycleTemplate(delta int) Model {
+	if len(m.templates) == 0 {
+		return m
+	}
+
+	next := m.templateIndex + delta
+	for next < 0 {
+		next += len(m.templates)
+	}
+	next = next % len(m.templates)
+
+	return m.selectTemplate(next)
+}
+
+func (m Model) cycleSize(delta int) Model {
+	entry, ok := m.currentTemplateEntry()
+	if !ok {
+		return m
+	}
+
+	sizes := entry.SupportedSizes
+	if len(sizes) == 0 {
+		return m
+	}
+
+	current := m.composition.Project.Page.Size
+	idx := 0
+	for i, size := range sizes {
+		if size == current {
+			idx = i
+			break
+		}
+	}
+
+	next := idx + delta
+	for next < 0 {
+		next += len(sizes)
+	}
+	next = next % len(sizes)
+
+	m.composition.Project.Page.Size = sizes[next]
+	return m
+}
+
+func (m Model) toggleOrientation() Model {
+	current := m.composition.Project.Page.Orientation
+	if current == domain.OrientationLandscape {
+		m.composition.Project.Page.Orientation = domain.OrientationPortrait
+	} else {
+		m.composition.Project.Page.Orientation = domain.OrientationLandscape
+	}
+
+	return m
+}
+
+func (m Model) appendContentRunes(runes []rune) Model {
+	if len(runes) == 0 {
+		return m
+	}
+
+	value := m.fieldValue(m.contentField)
+	value += string(runes)
+	return m.setFieldValue(m.contentField, value)
+}
+
+func (m Model) deleteContentRune() Model {
+	value := m.fieldValue(m.contentField)
+	if value == "" {
+		return m
+	}
+
+	_, size := utf8.DecodeLastRuneInString(value)
+	value = value[:len(value)-size]
+	return m.setFieldValue(m.contentField, value)
+}
+
+func (m Model) cycleContentField() Model {
+	m.contentField++
+	if m.contentField > FieldSignature {
+		m.contentField = FieldTitle
+	}
+
+	return m
+}
+
+func (m Model) fieldValue(field ContentField) string {
+	switch field {
+	case FieldTitle:
+		return m.composition.Project.Content.Title
+	case FieldBody:
+		return m.composition.Project.Content.Body
+	case FieldSignature:
+		return m.composition.Project.Content.Signature
+	default:
+		return ""
+	}
+}
+
+func (m Model) setFieldValue(field ContentField, value string) Model {
+	switch field {
+	case FieldTitle:
+		m.composition.Project.Content.Title = value
+	case FieldBody:
+		m.composition.Project.Content.Body = value
+	case FieldSignature:
+		m.composition.Project.Content.Signature = value
+	}
+
+	return m
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestViewShowsShellLayout(t *testing.T) {
@@ -14,6 +16,8 @@ func TestViewShowsShellLayout(t *testing.T) {
 		"Steps:",
 		"Template Selection",
 		"Review & Export",
+		"Available templates:",
+		"Use j/k to cycle templates",
 		"[Forward:",
 		"[Back:",
 		"[Quit:",
@@ -51,5 +55,68 @@ func TestStateAdvancesAndRewinds(t *testing.T) {
 
 	if model.composition.Summary() != initialSummary {
 		t.Fatalf("composition summary changed after navigation: before=%q after=%q", initialSummary, model.composition.Summary())
+	}
+}
+
+func TestTemplatePickerCycles(t *testing.T) {
+	model := NewModel()
+	if len(model.templates) < 2 {
+		t.Skip("at least two templates required for cycling")
+	}
+
+	nextIdx := (model.templateIndex + 1) % len(model.templates)
+	expected := model.templates[nextIdx].ID
+
+	model = model.cycleTemplate(1)
+	if model.composition.Project.Template != expected {
+		t.Fatalf("expected template %q after cycling, got %q", expected, model.composition.Project.Template)
+	}
+}
+
+func TestSizeSelectionAndOrientation(t *testing.T) {
+	model := NewModel()
+	model.state.Current = StepSize
+
+	entry, ok := model.currentTemplateEntry()
+	if !ok || len(entry.SupportedSizes) < 2 {
+		t.Skip("template needs at least two supported sizes")
+	}
+
+	initial := model.composition.Project.Page.Size
+	model = model.cycleSize(1)
+	if model.composition.Project.Page.Size == initial {
+		t.Fatalf("expected page size to change after cycling")
+	}
+
+	initialOrientation := model.composition.Project.Page.Orientation
+	model = model.toggleOrientation()
+	if model.composition.Project.Page.Orientation == initialOrientation {
+		t.Fatalf("expected orientation to toggle")
+	}
+}
+
+func TestContentEditingFields(t *testing.T) {
+	model := NewModel()
+	model.state.Current = StepContent
+	model.contentField = FieldTitle
+
+	model = model.appendContentRunes([]rune("Hello"))
+	if model.composition.Project.Content.Title != "Hello" {
+		t.Fatalf("expected title to update, got %q", model.composition.Project.Content.Title)
+	}
+
+	model = model.handleContentKey(tea.KeyMsg{Type: tea.KeyTab})
+	if model.contentField != FieldBody {
+		t.Fatalf("expected content field to cycle to Body, got %v", model.contentField)
+	}
+
+	model = model.appendContentRunes([]rune("Message"))
+	if model.composition.Project.Content.Body != "Message" {
+		t.Fatalf("expected body to update, got %q", model.composition.Project.Content.Body)
+	}
+
+	model = model.deleteContentRune()
+	if model.composition.Project.Content.Body != "Messag" {
+		t.Fatalf("expected body to trim last rune, got %q", model.composition.Project.Content.Body)
 	}
 }

--- a/internal/tui/catalog.go
+++ b/internal/tui/catalog.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"gopkg.in/yaml.v3"
+)
+
+type TemplateEntry struct {
+	ID                 string
+	Category           string
+	SupportedSizes     []domain.PageSize
+	DefaultOrientation domain.Orientation
+	Source             string
+}
+
+func loadTemplateEntries() []TemplateEntry {
+	root := templateDir()
+	if root == "" {
+		return nil
+	}
+
+	entries := []TemplateEntry{}
+
+	walk := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		normalized := filepath.ToSlash(relPath)
+
+		if d.IsDir() {
+			if normalized == "." {
+				return nil
+			}
+			if strings.HasPrefix(normalized, "assets") || strings.HasPrefix(normalized, "samples") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(d.Name()) != ".yaml" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		var tmpl domain.Template
+		if err := yaml.Unmarshal(data, &tmpl); err != nil {
+			return nil
+		}
+
+		if tmpl.ID == "" {
+			return nil
+		}
+
+		category := deriveCategory(normalized)
+
+		entry := TemplateEntry{
+			ID:                 tmpl.ID,
+			Category:           category,
+			SupportedSizes:     tmpl.Page.SupportedSizes,
+			DefaultOrientation: tmpl.Page.DefaultOrientation,
+			Source:             path,
+		}
+
+		if entry.DefaultOrientation == "" {
+			entry.DefaultOrientation = domain.OrientationPortrait
+		}
+
+		if len(entry.SupportedSizes) == 0 {
+			entry.SupportedSizes = []domain.PageSize{domain.PageSizeA4}
+		}
+
+		entries = append(entries, entry)
+		return nil
+	}
+
+	_ = filepath.WalkDir(root, walk)
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Category == entries[j].Category {
+			return entries[i].ID < entries[j].ID
+		}
+		return entries[i].Category < entries[j].Category
+	})
+
+	return entries
+}
+
+func deriveCategory(relPath string) string {
+	if relPath == "" {
+		return ""
+	}
+
+	segments := strings.Split(relPath, "/")
+	if len(segments) == 0 {
+		return ""
+	}
+
+	return segments[0]
+}
+
+func (e TemplateEntry) Label() string {
+	if e.Category != "" {
+		return e.ID + " (" + strings.Title(e.Category) + ")"
+	}
+	return e.ID
+}
+
+func templateDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(filename)))
+	return filepath.Join(projectRoot, "templates")
+}


### PR DESCRIPTION
## Summary\n- add template picker, size/orientation controls, and text editors inside the existing shell while mutating the shared CompositionState\n- load the starter templates catalogue from the repository so the picker can communicate supported sizes and categories\n- keep the navigation skeleton and placeholder routes in place while sharing the composition summary with the new screens\n\nCloses #17\n\n## Testing\n- go test ./...