### PR TITLE
Render image slots and simple decorations

### DIFF
--- a/internal/render/decoration.go
+++ b/internal/render/decoration.go
@@ -1,0 +1,47 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"github.com/tdewolff/canvas"
+)
+
+// RenderDecorationFrame draws a simple stroke frame around the slot when the decoration is enabled.
+func RenderDecorationFrame(ctx *canvas.Context, node Node, enabled bool) error {
+	if !enabled || node.Decoration == nil {
+		return nil
+	}
+
+	if err := validateDecorationAsset(node.Decoration); err != nil {
+		return err
+	}
+
+	width := float64(node.CanvasRect.WMM)
+	height := float64(node.CanvasRect.HMM)
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("slot %q has invalid bounds %vx%v", node.SlotID, width, height)
+	}
+
+	ctx.Push()
+	defer ctx.Pop()
+
+	ctx.SetFillColor(canvas.Transparent)
+	ctx.SetStrokeColor(canvas.Hex("#d98880"))
+	ctx.SetStrokeWidth(0.5)
+
+	path := canvas.Rectangle(width, height)
+	ctx.DrawPath(float64(node.CanvasRect.XMM), float64(node.CanvasRect.YMM), path)
+
+	return nil
+}
+
+func validateDecorationAsset(asset *domain.Asset) error {
+	if asset.Kind != domain.AssetKindDecoration {
+		return fmt.Errorf("asset %s is not a decoration", asset.ID)
+	}
+	if asset.Path == "" {
+		return fmt.Errorf("decoration asset %s has no path", asset.ID)
+	}
+	return nil
+}

--- a/internal/render/image.go
+++ b/internal/render/image.go
@@ -1,0 +1,87 @@
+package render
+
+import (
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"math"
+	"os"
+	"path/filepath"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"github.com/tdewolff/canvas"
+)
+
+// RenderImageSlot draws the image bound to the node into its canvas rect using the provided fit mode.
+func RenderImageSlot(ctx *canvas.Context, node Node, fit domain.FitMode) error {
+	if node.ImagePath == "" {
+		return nil
+	}
+
+	if node.CanvasRect.WMM <= 0 || node.CanvasRect.HMM <= 0 {
+		return fmt.Errorf("slot %q has invalid dimensions %v×%v", node.SlotID, node.CanvasRect.WMM, node.CanvasRect.HMM)
+	}
+
+	img, err := loadImage(node.ImagePath)
+	if err != nil {
+		return err
+	}
+
+	resolution, drawWidth, drawHeight, err := fitImageToSlot(node.SlotID, img.Bounds(), float64(node.CanvasRect.WMM), float64(node.CanvasRect.HMM), fit)
+	if err != nil {
+		return err
+	}
+
+	x := float64(node.CanvasRect.XMM) + (float64(node.CanvasRect.WMM)-drawWidth)/2
+	y := float64(node.CanvasRect.YMM) + (float64(node.CanvasRect.HMM)-drawHeight)/2
+
+	ctx.DrawImage(x, y, img, resolution)
+	return nil
+}
+
+func fitImageToSlot(slotID string, bounds image.Rectangle, slotWidthMM, slotHeightMM float64, fit domain.FitMode) (canvas.Resolution, float64, float64, error) {
+	if slotWidthMM <= 0 || slotHeightMM <= 0 {
+		return 0, 0, 0, fmt.Errorf("slot %q has non-positive dimensions %vx%v", slotID, slotWidthMM, slotHeightMM)
+	}
+	if bounds.Dx() <= 0 || bounds.Dy() <= 0 {
+		return 0, 0, 0, fmt.Errorf("slot %q source image has zero dimensions", slotID)
+	}
+
+	pixelWidth := float64(bounds.Dx())
+	pixelHeight := float64(bounds.Dy())
+
+	ratioX := pixelWidth / slotWidthMM
+	ratioY := pixelHeight / slotHeightMM
+
+	var scale float64
+	switch fit {
+	case domain.FitModeCover:
+		scale = math.Min(ratioX, ratioY)
+	default:
+		scale = math.Max(ratioX, ratioY)
+	}
+	if scale <= 0 {
+		scale = 1
+	}
+
+	resolution := canvas.DPMM(scale)
+	drawWidth := pixelWidth / scale
+	drawHeight := pixelHeight / scale
+
+	return resolution, drawWidth, drawHeight, nil
+}
+
+func loadImage(path string) (image.Image, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("open image %q: %w", path, err)
+	}
+	defer file.Close()
+
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return nil, fmt.Errorf("decode image %q: %w", path, err)
+	}
+	return img, nil
+}

--- a/internal/render/image_test.go
+++ b/internal/render/image_test.go
@@ -1,0 +1,134 @@
+package render
+
+import (
+	"errors"
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	"github.com/tdewolff/canvas"
+)
+
+func TestFitModeContainResolution(t *testing.T) {
+	resolution, width, height, err := fitImageToSlot("photo", image.Rect(0, 0, 400, 200), 80, 60, domain.FitModeContain)
+	if err != nil {
+		t.Fatalf("fitImageToSlot() error = %v", err)
+	}
+	if float64(resolution) != 5 {
+		t.Fatalf("resolution = %v, want 5", resolution)
+	}
+	if width != 80 {
+		t.Fatalf("draw width = %v, want 80", width)
+	}
+	if height != 40 {
+		t.Fatalf("draw height = %v, want 40", height)
+	}
+}
+
+func TestFitModeCoverResolution(t *testing.T) {
+	resolution, width, height, err := fitImageToSlot("photo", image.Rect(0, 0, 120, 60), 60, 30, domain.FitModeCover)
+	if err != nil {
+		t.Fatalf("fitImageToSlot() error = %v", err)
+	}
+	if float64(resolution) != 2 {
+		t.Fatalf("resolution = %v, want 2", resolution)
+	}
+	if width != 60 {
+		t.Fatalf("draw width = %v, want 60", width)
+	}
+	if height != 30 {
+		t.Fatalf("draw height = %v, want 30", height)
+	}
+}
+
+func TestRenderImageSlotMissingFile(t *testing.T) {
+	ctx := canvas.NewContext(canvas.New(100, 100))
+	node := Node{
+		SlotID:     "photo",
+		CanvasRect: Rect{WMM: 40, HMM: 40},
+		ImagePath:  "no/such/path.png",
+	}
+	err := RenderImageSlot(ctx, node, domain.FitModeContain)
+	if err == nil {
+		t.Fatal("expected error for missing image file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestRenderImageSlotDraws(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "hero.png")
+	f, err := os.Create(file)
+	if err != nil {
+		t.Fatalf("create sample image: %v", err)
+	}
+	img := image.NewNRGBA(image.Rect(0, 0, 40, 20))
+	if err := png.Encode(f, img); err != nil {
+		t.Fatalf("encode sample image: %v", err)
+	}
+	f.Close()
+
+	ctx := canvas.NewContext(canvas.New(200, 200))
+	node := Node{
+		SlotID: "photo",
+		CanvasRect: Rect{
+			XMM: 10,
+			YMM: 15,
+			WMM: 80,
+			HMM: 60,
+		},
+		ImagePath: file,
+	}
+
+	if err := RenderImageSlot(ctx, node, domain.FitModeContain); err != nil {
+		t.Fatalf("RenderImageSlot() error = %v", err)
+	}
+}
+
+func TestRenderDecorationFrameValidation(t *testing.T) {
+	ctx := canvas.NewContext(canvas.New(150, 150))
+	node := Node{
+		SlotID:     "frame",
+		CanvasRect: Rect{WMM: 60, HMM: 30},
+		Decoration: &domain.Asset{
+			ID:   "photo",
+			Kind: domain.AssetKindImage,
+			Path: "unused",
+		},
+	}
+
+	if err := RenderDecorationFrame(ctx, node, true); err == nil {
+		t.Fatal("expected error when decoration asset is not a decoration")
+	}
+}
+
+func TestRenderDecorationFrameDisabled(t *testing.T) {
+	ctx := canvas.NewContext(canvas.New(150, 150))
+	if err := RenderDecorationFrame(ctx, Node{
+		SlotID:     "frame",
+		CanvasRect: Rect{WMM: 60, HMM: 30},
+	}, false); err != nil {
+		t.Fatalf("RenderDecorationFrame() error = %v", err)
+	}
+}
+
+func TestRenderDecorationFrameDraws(t *testing.T) {
+	ctx := canvas.NewContext(canvas.New(150, 150))
+	node := Node{
+		SlotID:     "frame",
+		CanvasRect: Rect{XMM: 5, YMM: 5, WMM: 60, HMM: 30},
+		Decoration: &domain.Asset{
+			ID:   "corner-ornament",
+			Kind: domain.AssetKindDecoration,
+			Path: "assets/corner.svg",
+		},
+	}
+	if err := RenderDecorationFrame(ctx, node, true); err != nil {
+		t.Fatalf("RenderDecorationFrame() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add canvas helpers that load local images, math contain/cover scaling, and render into resolved slots
- add a lightweight decoration frame drawer that validates decoration assets before stroking slot bounds
- cover both helpers with tests for fit calculations, missing assets, and decoration validation

## Testing
- make test

Closes #6