### PR TITLE
Add CLI render command

### DIFF
--- a/cmd/letterpress/root.go
+++ b/cmd/letterpress/root.go
@@ -37,6 +37,7 @@ func NewRootCmd(deps Dependencies) *cobra.Command {
 	cmd.AddCommand(newTUICmd(deps))
 	cmd.AddCommand(cli.NewTemplatesCmd())
 	cmd.AddCommand(cli.NewValidateCmd())
+	cmd.AddCommand(cli.NewRenderCmd())
 	return cmd
 }
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+	exportpkg "github.com/jaeyoung0509/letterpress/internal/export"
+	"github.com/jaeyoung0509/letterpress/internal/projectio"
+	"github.com/jaeyoung0509/letterpress/internal/schema"
+	templatepkg "github.com/jaeyoung0509/letterpress/internal/template"
+)
+
+// NewRenderCmd returns a non-interactive render command.
+func NewRenderCmd() *cobra.Command {
+	var (
+		templatePath string
+		projectPath  string
+		outPath      string
+		formatFlag   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "Render a composition without launching the TUI",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRender(cmd.OutOrStdout(), templatePath, projectPath, formatFlag, outPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&templatePath, "template", "", "path to a template YAML file")
+	cmd.Flags().StringVar(&projectPath, "project", "", "path to a project YAML file")
+	cmd.Flags().StringVar(&formatFlag, "format", "", "override output format (pdf or png)")
+	cmd.Flags().StringVar(&outPath, "out", "", "override output path")
+
+	return cmd
+}
+
+func runRender(out io.Writer, templatePath, projectPath, formatFlag, outPath string) error {
+	if strings.TrimSpace(templatePath) == "" {
+		return fmt.Errorf("template path is required")
+	}
+	if strings.TrimSpace(projectPath) == "" {
+		return fmt.Errorf("project path is required")
+	}
+
+	tmpl, err := schema.LoadTemplateFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("load template: %w", err)
+	}
+
+	project, err := projectio.Load(projectPath)
+	if err != nil {
+		return fmt.Errorf("load project: %w", err)
+	}
+
+	resolved, err := templatepkg.Resolve(tmpl, project)
+	if err != nil {
+		return fmt.Errorf("resolve template and project: %w", err)
+	}
+
+	format, target, err := resolveRenderTarget(project, formatFlag, outPath)
+	if err != nil {
+		return err
+	}
+
+	written, err := exportpkg.ComposeAndWrite(resolved, exportpkg.Options{
+		Format:      format,
+		Out:         target,
+		Decorations: project.Options.Decorations,
+	})
+	if err != nil {
+		return fmt.Errorf("render export: %w", err)
+	}
+
+	fmt.Fprintf(out, "rendered %s to %s\n", tmpl.ID, written)
+	return nil
+}
+
+func resolveRenderTarget(project domain.Project, formatFlag, outPath string) (domain.ExportFormat, string, error) {
+	target := strings.TrimSpace(outPath)
+	if target == "" {
+		target = strings.TrimSpace(project.Export.Out)
+	}
+	if target == "" {
+		return "", "", fmt.Errorf("output path is required via --out or project export settings")
+	}
+
+	format := domain.ExportFormat(strings.ToLower(strings.TrimSpace(formatFlag)))
+	if format == "" {
+		format = project.Export.Format
+	}
+	if format == "" {
+		format = inferFormatFromPath(target)
+	}
+	if format != domain.ExportFormatPDF && format != domain.ExportFormatPNG {
+		return "", "", fmt.Errorf("render format must be pdf or png")
+	}
+
+	ext := strings.ToLower(filepath.Ext(target))
+	if ext != "" && ext != "."+string(format) {
+		return "", "", fmt.Errorf("output path %q does not match format %s", target, format)
+	}
+
+	return format, target, nil
+}
+
+func inferFormatFromPath(path string) domain.ExportFormat {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".pdf":
+		return domain.ExportFormatPDF
+	case ".png":
+		return domain.ExportFormatPNG
+	default:
+		return ""
+	}
+}

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyoung0509/letterpress/internal/domain"
+)
+
+func TestRenderCommandExportsPDF(t *testing.T) {
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "template.yaml")
+	projectPath := filepath.Join(dir, "project.yaml")
+	outPath := filepath.Join(dir, "output", "card.pdf")
+
+	writeSampleTemplate(t, templatePath, "classic-letter")
+	writeSampleProject(t, projectPath, "classic-letter")
+
+	cmd := NewRenderCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{
+		"--template", templatePath,
+		"--project", projectPath,
+		"--out", outPath,
+		"--format", "pdf",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("render command failed: %v", err)
+	}
+
+	if !strings.Contains(output.String(), "rendered classic-letter") {
+		t.Fatalf("unexpected render output: %q", output.String())
+	}
+	if info, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	} else if info.Size() == 0 {
+		t.Fatalf("expected output file to be non-empty")
+	}
+}
+
+func TestResolveRenderTargetUsesProjectDefaults(t *testing.T) {
+	project := domain.Project{
+		Export: domain.ExportOptions{
+			Format: domain.ExportFormatPNG,
+			Out:    "outputs/card.png",
+		},
+	}
+
+	format, out, err := resolveRenderTarget(project, "", "")
+	if err != nil {
+		t.Fatalf("resolveRenderTarget() error = %v", err)
+	}
+	if format != domain.ExportFormatPNG {
+		t.Fatalf("format = %q, want png", format)
+	}
+	if out != "outputs/card.png" {
+		t.Fatalf("out = %q, want outputs/card.png", out)
+	}
+}
+
+func TestResolveRenderTargetRejectsMismatchedPath(t *testing.T) {
+	project := domain.Project{}
+	if _, _, err := resolveRenderTarget(project, "png", "out/card.pdf"); err == nil {
+		t.Fatal("expected mismatched output path to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add a non-interactive render command that loads template/project inputs and calls the public export pipeline
- infer or validate the output target from flags and project export settings without touching renderer internals
- cover command wiring, render-target resolution, and a real PDF export in CLI tests

## Testing
- go test ./internal/cli -v
- make test
- manual check: `go run . render --template templates/letter/classic-letter-a4.yaml --project templates/samples/classic-letter-project.yaml --format pdf --out /tmp/letterpress-cli-render.pdf`

Closes #22
