### PR TITLE
Improve text-art quality and add vector contour PDF beta

### DIFF
--- a/internal/ascii/ascii.go
+++ b/internal/ascii/ascii.go
@@ -39,6 +39,7 @@ type Art struct {
 	Height   int
 	Charset  string
 	FillText string
+	FillFont domain.FillFont
 	Lines    []string
 	Cells    [][]Cell
 }
@@ -59,6 +60,8 @@ type options struct {
 	mode            domain.ASCIIMode
 	toneCharset     []rune
 	fillText        []rune
+	fillFont        domain.FillFont
+	fillTile        []string
 	density         int
 	threshold       float64
 	contrast        float64
@@ -124,7 +127,7 @@ func RenderImage(img image.Image, config domain.ASCIIOptions) (Art, error) {
 			occupied := occupancy[y][x]
 			signal := toneSignals[y][x]
 
-			glyph := renderGlyph(opts, signal, edge, occupied, &fillCursor)
+			glyph := renderGlyph(opts, x, y, signal, edge, occupied, &fillCursor)
 			cells[y][x] = Cell{
 				Glyph:     glyph,
 				Luminance: lum,
@@ -144,6 +147,7 @@ func RenderImage(img image.Image, config domain.ASCIIOptions) (Art, error) {
 		Height:   rows,
 		Charset:  string(opts.toneCharset),
 		FillText: string(opts.fillText),
+		FillFont: opts.fillFont,
 		Lines:    lines,
 		Cells:    cells,
 	}, nil
@@ -162,6 +166,7 @@ func normalize(config domain.ASCIIOptions) options {
 	}
 
 	fillText := []rune(normalizeFillText(config.FillText))
+	fillFont := config.EffectiveFillFont()
 
 	density := config.Density
 	if density <= 0 {
@@ -197,6 +202,8 @@ func normalize(config domain.ASCIIOptions) options {
 		mode:            mode,
 		toneCharset:     toneCharset,
 		fillText:        fillText,
+		fillFont:        fillFont,
+		fillTile:        buildFillTile(fillFont, string(fillText)),
 		density:         density,
 		threshold:       clamp01(config.Threshold),
 		contrast:        contrast,
@@ -481,7 +488,7 @@ func quantizeSignal(value float64, levels int) float64 {
 	return float64(index) / float64(levels-1)
 }
 
-func renderGlyph(opts options, signal, edge float64, occupied bool, fillCursor *int) rune {
+func renderGlyph(opts options, x, y int, signal, edge float64, occupied bool, fillCursor *int) rune {
 	switch opts.mode {
 	case domain.ASCIIModeOutline:
 		if edge < opts.edgeThreshold {
@@ -490,7 +497,7 @@ func renderGlyph(opts options, signal, edge float64, occupied bool, fillCursor *
 		return selectGlyph(opts.toneCharset, clamp01(1-edge))
 	case domain.ASCIIModeFill:
 		if occupied {
-			return nextFillRune(opts.fillText, fillCursor)
+			return fillRuneAt(opts, x, y, fillCursor)
 		}
 		return ' '
 	case domain.ASCIIModeHybrid, domain.ASCIIModeVector:
@@ -498,7 +505,7 @@ func renderGlyph(opts options, signal, edge float64, occupied bool, fillCursor *
 			return selectGlyph(opts.toneCharset, clamp01(1-edge))
 		}
 		if occupied {
-			return nextFillRune(opts.fillText, fillCursor)
+			return fillRuneAt(opts, x, y, fillCursor)
 		}
 		return ' '
 	case domain.ASCIIModeTone:
@@ -508,6 +515,16 @@ func renderGlyph(opts options, signal, edge float64, occupied bool, fillCursor *
 	}
 }
 
+func fillRuneAt(opts options, x, y int, cursor *int) rune {
+	switch opts.fillFont {
+	case domain.FillFontRepeat, domain.FillFontBlock:
+		if glyph, ok := tileRune(opts.fillTile, x, y); ok {
+			return glyph
+		}
+	}
+	return nextFillRune(opts.fillText, cursor)
+}
+
 func nextFillRune(fill []rune, cursor *int) rune {
 	if len(fill) == 0 {
 		fill = []rune(DefaultFillText)
@@ -515,6 +532,17 @@ func nextFillRune(fill []rune, cursor *int) rune {
 	r := fill[*cursor%len(fill)]
 	*cursor++
 	return r
+}
+
+func tileRune(tile []string, x, y int) (rune, bool) {
+	if len(tile) == 0 {
+		return 0, false
+	}
+	row := []rune(tile[y%len(tile)])
+	if len(row) == 0 {
+		return 0, false
+	}
+	return row[x%len(row)], true
 }
 
 func ExtractContourSegments(art Art, edgeThreshold float64) []Segment {
@@ -703,6 +731,126 @@ func normalizeFillText(value string) string {
 	value = strings.NewReplacer("\r", " ", "\n", " ", "\t", " ").Replace(value)
 	value = strings.Join(strings.Fields(value), " ")
 	return value
+}
+
+func buildFillTile(font domain.FillFont, fillText string) []string {
+	switch font {
+	case domain.FillFontRepeat:
+		return buildRepeatTile(fillText)
+	case domain.FillFontBlock:
+		return buildBlockTile(fillText)
+	default:
+		return nil
+	}
+}
+
+func buildRepeatTile(fillText string) []string {
+	fillText = normalizeFillText(fillText)
+	if fillText == "" {
+		fillText = DefaultFillText
+	}
+	return []string{fillText + " "}
+}
+
+func buildBlockTile(fillText string) []string {
+	fillText = strings.ToUpper(normalizeFillText(fillText))
+	if fillText == "" {
+		fillText = DefaultFillText
+	}
+
+	rows := make([]strings.Builder, 5)
+	runes := []rune(fillText)
+	for i, r := range runes {
+		pattern := blockPatternForRune(r)
+		mark := blockMarkRune(r)
+		for rowIndex, rowPattern := range pattern {
+			for _, cell := range rowPattern {
+				if cell != ' ' {
+					rows[rowIndex].WriteRune(mark)
+				} else {
+					rows[rowIndex].WriteRune(' ')
+				}
+			}
+			if i < len(runes)-1 {
+				rows[rowIndex].WriteRune(' ')
+			}
+		}
+	}
+
+	lines := make([]string, 5)
+	for i := range rows {
+		lines[i] = rows[i].String()
+	}
+	return lines
+}
+
+func blockMarkRune(r rune) rune {
+	switch {
+	case r == ' ':
+		return ' '
+	case r >= 'A' && r <= 'Z':
+		return r
+	case r >= '0' && r <= '9':
+		return r
+	default:
+		return '#'
+	}
+}
+
+func blockPatternForRune(r rune) []string {
+	if pattern, ok := blockAlphabet[r]; ok {
+		return pattern
+	}
+	return []string{
+		"###",
+		"# #",
+		"# #",
+		"# #",
+		"###",
+	}
+}
+
+var blockAlphabet = map[rune][]string{
+	' ': {"   ", "   ", "   ", "   ", "   "},
+	'!': {" # ", " # ", " # ", "   ", " # "},
+	'.': {"   ", "   ", "   ", "   ", " # "},
+	'-': {"   ", "   ", "###", "   ", "   "},
+	'0': {"###", "# #", "# #", "# #", "###"},
+	'1': {" # ", "## ", " # ", " # ", "###"},
+	'2': {"###", "  #", "###", "#  ", "###"},
+	'3': {"###", "  #", " ##", "  #", "###"},
+	'4': {"# #", "# #", "###", "  #", "  #"},
+	'5': {"###", "#  ", "###", "  #", "###"},
+	'6': {"###", "#  ", "###", "# #", "###"},
+	'7': {"###", "  #", "  #", " # ", " # "},
+	'8': {"###", "# #", "###", "# #", "###"},
+	'9': {"###", "# #", "###", "  #", "###"},
+	'A': {"###", "# #", "###", "# #", "# #"},
+	'B': {"## ", "# #", "## ", "# #", "## "},
+	'C': {"###", "#  ", "#  ", "#  ", "###"},
+	'D': {"## ", "# #", "# #", "# #", "## "},
+	'E': {"###", "#  ", "## ", "#  ", "###"},
+	'F': {"###", "#  ", "## ", "#  ", "#  "},
+	'G': {"###", "#  ", "# #", "# #", "###"},
+	'H': {"# #", "# #", "###", "# #", "# #"},
+	'I': {"###", " # ", " # ", " # ", "###"},
+	'J': {"###", "  #", "  #", "# #", "###"},
+	'K': {"# #", "# #", "## ", "# #", "# #"},
+	'L': {"#  ", "#  ", "#  ", "#  ", "###"},
+	'M': {"# #", "###", "###", "# #", "# #"},
+	'N': {"# #", "###", "###", "###", "# #"},
+	'O': {"###", "# #", "# #", "# #", "###"},
+	'P': {"###", "# #", "###", "#  ", "#  "},
+	'Q': {"###", "# #", "# #", "###", "  #"},
+	'R': {"###", "# #", "###", "## ", "# #"},
+	'S': {"###", "#  ", "###", "  #", "###"},
+	'T': {"###", " # ", " # ", " # ", " # "},
+	'U': {"# #", "# #", "# #", "# #", "###"},
+	'V': {"# #", "# #", "# #", "# #", " # "},
+	'W': {"# #", "# #", "###", "###", "# #"},
+	'X': {"# #", "# #", " # ", "# #", "# #"},
+	'Y': {"# #", "# #", "###", " # ", " # "},
+	'Z': {"###", "  #", " # ", "#  ", "###"},
 }
 
 func at(grid [][]float64, x, y int) float64 {

--- a/internal/ascii/ascii.go
+++ b/internal/ascii/ascii.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/jaeyoung0509/letterpress/internal/domain"
@@ -15,10 +16,13 @@ import (
 )
 
 const (
-	DefaultCharset         = "@%#*+=-:. "
+	DefaultToneCharset     = "@%#*+=-:. "
 	DefaultDensity         = 80
 	DefaultContrast        = 1.0
+	DefaultGamma           = 1.0
 	DefaultCellAspectRatio = 0.5
+	DefaultEdgeThreshold   = 0.28
+	DefaultFillText        = "LETTERPRESS"
 )
 
 type Cell struct {
@@ -26,27 +30,43 @@ type Cell struct {
 	Luminance float64
 	Edge      float64
 	Signal    float64
+	Occupied  bool
 }
 
 type Art struct {
-	Width   int
-	Height  int
-	Charset string
-	Lines   []string
-	Cells   [][]Cell
+	Mode     domain.ASCIIMode
+	Width    int
+	Height   int
+	Charset  string
+	FillText string
+	Lines    []string
+	Cells    [][]Cell
 }
 
 func (a Art) String() string {
 	return strings.Join(a.Lines, "\n")
 }
 
+type Segment struct {
+	X1     float64
+	Y1     float64
+	X2     float64
+	Y2     float64
+	Weight float64
+}
+
 type options struct {
-	charset         []rune
+	mode            domain.ASCIIMode
+	toneCharset     []rune
+	fillText        []rune
 	density         int
 	threshold       float64
 	contrast        float64
+	gamma           float64
 	invert          bool
 	edgeWeight      float64
+	edgeThreshold   float64
+	dither          domain.DitherMode
 	cellAspectRatio float64
 }
 
@@ -76,10 +96,22 @@ func RenderImage(img image.Image, config domain.ASCIIOptions) (Art, error) {
 	}
 
 	opts := normalize(config)
-	columns, rows := gridDimensions(bounds.Dx(), bounds.Dy(), opts.density, opts.cellAspectRatio)
-	luminance := sampleLuminance(img, opts.contrast, columns, rows)
-	edges := edgeStrengths(luminance)
+	if requiresFillText(opts.mode) && len(opts.fillText) == 0 {
+		return Art{}, fmt.Errorf("fill text is required for %s mode", opts.mode)
+	}
 
+	columns, rows := gridDimensions(bounds.Dx(), bounds.Dy(), opts.density, opts.cellAspectRatio)
+	pixels := normalizedLuminance(img, opts.contrast, opts.gamma)
+	luminance := sampleGrid(pixels, columns, rows)
+	edges := sobelEdges(luminance)
+	occupancy := occupancyMap(luminance, opts)
+	toneSignals := toneSignalGrid(luminance, edges, opts)
+
+	if opts.dither == domain.DitherModeFloyd && (opts.mode == domain.ASCIIModeTone || opts.mode == domain.ASCIIModeHybrid) {
+		toneSignals = ditherGrid(toneSignals, len(opts.toneCharset))
+	}
+
+	fillCursor := 0
 	cells := make([][]Cell, rows)
 	lines := make([]string, rows)
 	for y := 0; y < rows; y++ {
@@ -87,24 +119,18 @@ func RenderImage(img image.Image, config domain.ASCIIOptions) (Art, error) {
 		var builder strings.Builder
 
 		for x := 0; x < columns; x++ {
-			signal := mixSignal(luminance[y][x], edges[y][x], opts.edgeWeight)
-			if opts.invert {
-				signal = 1 - signal
-			}
-			if opts.threshold > 0 {
-				if signal >= opts.threshold {
-					signal = 1
-				} else {
-					signal = 0
-				}
-			}
+			lum := luminance[y][x]
+			edge := edges[y][x]
+			occupied := occupancy[y][x]
+			signal := toneSignals[y][x]
 
-			glyph := selectGlyph(opts.charset, signal)
+			glyph := renderGlyph(opts, signal, edge, occupied, &fillCursor)
 			cells[y][x] = Cell{
 				Glyph:     glyph,
-				Luminance: luminance[y][x],
-				Edge:      edges[y][x],
-				Signal:    clamp01(signal),
+				Luminance: lum,
+				Edge:      edge,
+				Signal:    signal,
+				Occupied:  occupied,
 			}
 			builder.WriteRune(glyph)
 		}
@@ -113,24 +139,29 @@ func RenderImage(img image.Image, config domain.ASCIIOptions) (Art, error) {
 	}
 
 	return Art{
-		Width:   columns,
-		Height:  rows,
-		Charset: string(opts.charset),
-		Lines:   lines,
-		Cells:   cells,
+		Mode:     opts.mode,
+		Width:    columns,
+		Height:   rows,
+		Charset:  string(opts.toneCharset),
+		FillText: string(opts.fillText),
+		Lines:    lines,
+		Cells:    cells,
 	}, nil
 }
 
 func normalize(config domain.ASCIIOptions) options {
-	charsetValue := config.Charset
-	if strings.TrimSpace(charsetValue) == "" {
-		charsetValue = DefaultCharset
+	mode := config.EffectiveMode()
+
+	toneCharsetValue := config.EffectiveToneCharset()
+	if strings.TrimSpace(toneCharsetValue) == "" {
+		toneCharsetValue = DefaultToneCharset
+	}
+	toneCharset := []rune(toneCharsetValue)
+	if len(toneCharset) == 0 {
+		toneCharset = []rune(DefaultToneCharset)
 	}
 
-	charset := []rune(charsetValue)
-	if len(charset) == 0 {
-		charset = []rune(DefaultCharset)
-	}
+	fillText := []rune(normalizeFillText(config.FillText))
 
 	density := config.Density
 	if density <= 0 {
@@ -142,14 +173,48 @@ func normalize(config domain.ASCIIOptions) options {
 		contrast = DefaultContrast
 	}
 
+	gamma := config.Gamma
+	if gamma <= 0 {
+		gamma = DefaultGamma
+	}
+
+	cellAspect := config.CellAspect
+	if cellAspect <= 0 {
+		cellAspect = DefaultCellAspectRatio
+	}
+
+	edgeThreshold := clamp01(config.EdgeThreshold)
+	if edgeThreshold == 0 {
+		edgeThreshold = DefaultEdgeThreshold
+	}
+
+	dither := config.Dither
+	if dither == "" {
+		dither = domain.DitherModeOff
+	}
+
 	return options{
-		charset:         charset,
+		mode:            mode,
+		toneCharset:     toneCharset,
+		fillText:        fillText,
 		density:         density,
 		threshold:       clamp01(config.Threshold),
 		contrast:        contrast,
+		gamma:           gamma,
 		invert:          config.Invert,
 		edgeWeight:      clamp01(config.EdgeWeight),
-		cellAspectRatio: DefaultCellAspectRatio,
+		edgeThreshold:   edgeThreshold,
+		dither:          dither,
+		cellAspectRatio: cellAspect,
+	}
+}
+
+func requiresFillText(mode domain.ASCIIMode) bool {
+	switch mode {
+	case domain.ASCIIModeFill, domain.ASCIIModeHybrid, domain.ASCIIModeVector:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -170,21 +235,49 @@ func gridDimensions(width, height, density int, aspect float64) (int, int) {
 	return columns, rows
 }
 
-func sampleLuminance(img image.Image, contrast float64, columns, rows int) [][]float64 {
+func normalizedLuminance(img image.Image, contrast, gamma float64) [][]float64 {
 	bounds := img.Bounds()
 	width := bounds.Dx()
 	height := bounds.Dy()
 
 	pixels := make([][]float64, height)
+	minLum := 1.0
+	maxLum := 0.0
 	for y := 0; y < height; y++ {
 		row := make([]float64, width)
 		for x := 0; x < width; x++ {
 			r, g, b, _ := img.At(bounds.Min.X+x, bounds.Min.Y+y).RGBA()
 			luminance := (0.2126*float64(r) + 0.7152*float64(g) + 0.0722*float64(b)) / 65535.0
-			row[x] = applyContrast(luminance, contrast)
+			row[x] = luminance
+			if luminance < minLum {
+				minLum = luminance
+			}
+			if luminance > maxLum {
+				maxLum = luminance
+			}
 		}
 		pixels[y] = row
 	}
+
+	span := maxLum - minLum
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			value := pixels[y][x]
+			if span > 1e-6 {
+				value = (value - minLum) / span
+			}
+			value = applyGamma(value, gamma)
+			value = applyContrast(value, contrast)
+			pixels[y][x] = clamp01(value)
+		}
+	}
+
+	return pixels
+}
+
+func sampleGrid(pixels [][]float64, columns, rows int) [][]float64 {
+	height := len(pixels)
+	width := len(pixels[0])
 
 	integral := integralImage(pixels)
 	sampled := make([][]float64, rows)
@@ -196,7 +289,6 @@ func sampleLuminance(img image.Image, contrast float64, columns, rows int) [][]f
 			sampled[y][x] = regionAverage(integral, x0, y0, x1, y1)
 		}
 	}
-
 	return sampled
 }
 
@@ -247,40 +339,376 @@ func regionAverage(integral [][]float64, x0, y0, x1, y1 int) float64 {
 	return sum / area
 }
 
-func edgeStrengths(luminance [][]float64) [][]float64 {
+func sobelEdges(luminance [][]float64) [][]float64 {
 	height := len(luminance)
 	width := len(luminance[0])
 
 	edges := make([][]float64, height)
+	maxMag := 0.0
 	for y := 0; y < height; y++ {
 		edges[y] = make([]float64, width)
 		for x := 0; x < width; x++ {
-			left := luminance[y][maxInt(0, x-1)]
-			right := luminance[y][minInt(width-1, x+1)]
-			up := luminance[maxInt(0, y-1)][x]
-			down := luminance[minInt(height-1, y+1)][x]
-
-			edges[y][x] = clamp01((math.Abs(right-left) + math.Abs(down-up)) / 2)
+			gx := -at(luminance, x-1, y-1) + at(luminance, x+1, y-1) +
+				-2*at(luminance, x-1, y) + 2*at(luminance, x+1, y) +
+				-at(luminance, x-1, y+1) + at(luminance, x+1, y+1)
+			gy := at(luminance, x-1, y-1) + 2*at(luminance, x, y-1) + at(luminance, x+1, y-1) +
+				-at(luminance, x-1, y+1) - 2*at(luminance, x, y+1) - at(luminance, x+1, y+1)
+			mag := math.Sqrt(gx*gx + gy*gy)
+			edges[y][x] = mag
+			if mag > maxMag {
+				maxMag = mag
+			}
 		}
 	}
 
+	if maxMag <= 1e-6 {
+		return edges
+	}
+	for y := range edges {
+		for x := range edges[y] {
+			edges[y][x] = clamp01(edges[y][x] / maxMag)
+		}
+	}
 	return edges
 }
 
-func mixSignal(luminance, edge, edgeWeight float64) float64 {
-	return clamp01((1-edgeWeight)*luminance + edgeWeight*(1-edge))
+func toneSignalGrid(luminance, edges [][]float64, opts options) [][]float64 {
+	height := len(luminance)
+	width := len(luminance[0])
+	signals := make([][]float64, height)
+	edgeWeight := effectiveEdgeWeight(opts)
+
+	for y := 0; y < height; y++ {
+		signals[y] = make([]float64, width)
+		for x := 0; x < width; x++ {
+			brightness := effectiveBrightness(luminance[y][x], opts.invert)
+			signals[y][x] = mixSignal(brightness, edges[y][x], edgeWeight)
+		}
+	}
+
+	return signals
+}
+
+func effectiveEdgeWeight(opts options) float64 {
+	if opts.edgeWeight > 0 {
+		return opts.edgeWeight
+	}
+	switch opts.mode {
+	case domain.ASCIIModeOutline:
+		return 1.0
+	case domain.ASCIIModeHybrid, domain.ASCIIModeVector:
+		return 0.55
+	default:
+		return 0
+	}
+}
+
+func occupancyMap(luminance [][]float64, opts options) [][]bool {
+	height := len(luminance)
+	width := len(luminance[0])
+	mask := make([][]bool, height)
+
+	for y := 0; y < height; y++ {
+		mask[y] = make([]bool, width)
+		for x := 0; x < width; x++ {
+			darkness := 1 - effectiveBrightness(luminance[y][x], opts.invert)
+			threshold := opts.threshold
+			if threshold <= 0 {
+				local := localAverageDarkness(luminance, x, y, opts.invert)
+				threshold = clamp01(local*0.88 + 0.04)
+			}
+			mask[y][x] = darkness >= threshold
+		}
+	}
+
+	return mask
+}
+
+func localAverageDarkness(luminance [][]float64, x, y int, invert bool) float64 {
+	sum := 0.0
+	count := 0.0
+	for yy := maxInt(0, y-1); yy <= minInt(len(luminance)-1, y+1); yy++ {
+		for xx := maxInt(0, x-1); xx <= minInt(len(luminance[0])-1, x+1); xx++ {
+			sum += 1 - effectiveBrightness(luminance[yy][xx], invert)
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	return sum / count
+}
+
+func ditherGrid(signal [][]float64, levels int) [][]float64 {
+	height := len(signal)
+	width := len(signal[0])
+
+	out := make([][]float64, height)
+	for y := 0; y < height; y++ {
+		out[y] = make([]float64, width)
+		copy(out[y], signal[y])
+	}
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			oldValue := clamp01(out[y][x])
+			newValue := quantizeSignal(oldValue, levels)
+			err := oldValue - newValue
+			out[y][x] = newValue
+
+			diffuse(out, x+1, y, err*7.0/16.0)
+			diffuse(out, x-1, y+1, err*3.0/16.0)
+			diffuse(out, x, y+1, err*5.0/16.0)
+			diffuse(out, x+1, y+1, err*1.0/16.0)
+		}
+	}
+
+	return out
+}
+
+func diffuse(grid [][]float64, x, y int, delta float64) {
+	if y < 0 || y >= len(grid) || x < 0 || x >= len(grid[0]) {
+		return
+	}
+	grid[y][x] = clamp01(grid[y][x] + delta)
+}
+
+func quantizeSignal(value float64, levels int) float64 {
+	if levels <= 1 {
+		return clamp01(value)
+	}
+	index := int(math.Round(clamp01(value) * float64(levels-1)))
+	return float64(index) / float64(levels-1)
+}
+
+func renderGlyph(opts options, signal, edge float64, occupied bool, fillCursor *int) rune {
+	switch opts.mode {
+	case domain.ASCIIModeOutline:
+		if edge < opts.edgeThreshold {
+			return ' '
+		}
+		return selectGlyph(opts.toneCharset, clamp01(1-edge))
+	case domain.ASCIIModeFill:
+		if occupied {
+			return nextFillRune(opts.fillText, fillCursor)
+		}
+		return ' '
+	case domain.ASCIIModeHybrid, domain.ASCIIModeVector:
+		if edge >= opts.edgeThreshold {
+			return selectGlyph(opts.toneCharset, clamp01(1-edge))
+		}
+		if occupied {
+			return nextFillRune(opts.fillText, fillCursor)
+		}
+		return ' '
+	case domain.ASCIIModeTone:
+		fallthrough
+	default:
+		return selectGlyph(opts.toneCharset, signal)
+	}
+}
+
+func nextFillRune(fill []rune, cursor *int) rune {
+	if len(fill) == 0 {
+		fill = []rune(DefaultFillText)
+	}
+	r := fill[*cursor%len(fill)]
+	*cursor++
+	return r
+}
+
+func ExtractContourSegments(art Art, edgeThreshold float64) []Segment {
+	if art.Width == 0 || art.Height == 0 || len(art.Cells) == 0 {
+		return nil
+	}
+	threshold := clamp01(edgeThreshold)
+	if threshold == 0 {
+		threshold = DefaultEdgeThreshold
+	}
+
+	visited := make([][]bool, art.Height)
+	for y := range visited {
+		visited[y] = make([]bool, art.Width)
+	}
+
+	segments := make([]Segment, 0, 32)
+	for y := 0; y < art.Height; y++ {
+		for x := 0; x < art.Width; x++ {
+			if visited[y][x] || art.Cells[y][x].Edge < threshold {
+				continue
+			}
+			component := traceComponent(art, visited, x, y, threshold)
+			if len(component) == 0 {
+				continue
+			}
+			segment := componentToSegment(component)
+			if segment.Weight <= 0 {
+				continue
+			}
+			segments = append(segments, segment)
+		}
+	}
+
+	sort.Slice(segments, func(i, j int) bool {
+		return segmentScore(segments[i]) > segmentScore(segments[j])
+	})
+	if len(segments) > 96 {
+		segments = segments[:96]
+	}
+	return segments
+}
+
+type point struct {
+	x      float64
+	y      float64
+	weight float64
+}
+
+func traceComponent(art Art, visited [][]bool, startX, startY int, threshold float64) []point {
+	queue := [][2]int{{startX, startY}}
+	visited[startY][startX] = true
+	points := make([]point, 0, 12)
+
+	for len(queue) > 0 {
+		cell := queue[0]
+		queue = queue[1:]
+
+		x := cell[0]
+		y := cell[1]
+		edge := art.Cells[y][x].Edge
+		points = append(points, point{
+			x:      float64(x) + 0.5,
+			y:      float64(y) + 0.5,
+			weight: edge,
+		})
+
+		for ny := maxInt(0, y-1); ny <= minInt(art.Height-1, y+1); ny++ {
+			for nx := maxInt(0, x-1); nx <= minInt(art.Width-1, x+1); nx++ {
+				if visited[ny][nx] || art.Cells[ny][nx].Edge < threshold {
+					continue
+				}
+				visited[ny][nx] = true
+				queue = append(queue, [2]int{nx, ny})
+			}
+		}
+	}
+
+	return points
+}
+
+func componentToSegment(points []point) Segment {
+	if len(points) == 0 {
+		return Segment{}
+	}
+	if len(points) == 1 {
+		p := points[0]
+		return Segment{
+			X1:     p.x - 0.45,
+			Y1:     p.y,
+			X2:     p.x + 0.45,
+			Y2:     p.y,
+			Weight: p.weight,
+		}
+	}
+
+	cx := 0.0
+	cy := 0.0
+	weight := 0.0
+	for _, p := range points {
+		cx += p.x
+		cy += p.y
+		weight += p.weight
+	}
+	cx /= float64(len(points))
+	cy /= float64(len(points))
+	weight /= float64(len(points))
+
+	xx, xy, yy := 0.0, 0.0, 0.0
+	for _, p := range points {
+		dx := p.x - cx
+		dy := p.y - cy
+		xx += dx * dx
+		xy += dx * dy
+		yy += dy * dy
+	}
+	theta := 0.5 * math.Atan2(2*xy, xx-yy)
+	dirX := math.Cos(theta)
+	dirY := math.Sin(theta)
+
+	minProj := math.MaxFloat64
+	maxProj := -math.MaxFloat64
+	for _, p := range points {
+		proj := (p.x-cx)*dirX + (p.y-cy)*dirY
+		if proj < minProj {
+			minProj = proj
+		}
+		if proj > maxProj {
+			maxProj = proj
+		}
+	}
+
+	if maxProj-minProj < 0.9 {
+		maxProj = 0.45
+		minProj = -0.45
+	}
+
+	return Segment{
+		X1:     cx + dirX*minProj,
+		Y1:     cy + dirY*minProj,
+		X2:     cx + dirX*maxProj,
+		Y2:     cy + dirY*maxProj,
+		Weight: weight,
+	}
+}
+
+func segmentScore(segment Segment) float64 {
+	return segment.Weight * math.Hypot(segment.X2-segment.X1, segment.Y2-segment.Y1)
+}
+
+func mixSignal(brightness, edge, edgeWeight float64) float64 {
+	return clamp01((1-edgeWeight)*brightness + edgeWeight*(1-edge))
 }
 
 func selectGlyph(charset []rune, signal float64) rune {
 	if len(charset) == 0 {
-		charset = []rune(DefaultCharset)
+		charset = []rune(DefaultToneCharset)
 	}
 	index := int(math.Round(clamp01(signal) * float64(len(charset)-1)))
 	return charset[index]
 }
 
+func effectiveBrightness(value float64, invert bool) float64 {
+	if invert {
+		return 1 - value
+	}
+	return value
+}
+
+func applyGamma(value, gamma float64) float64 {
+	if gamma <= 0 {
+		return clamp01(value)
+	}
+	return clamp01(math.Pow(clamp01(value), 1.0/gamma))
+}
+
 func applyContrast(value, contrast float64) float64 {
 	return clamp01((value-0.5)*contrast + 0.5)
+}
+
+func normalizeFillText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.NewReplacer("\r", " ", "\n", " ", "\t", " ").Replace(value)
+	value = strings.Join(strings.Fields(value), " ")
+	return value
+}
+
+func at(grid [][]float64, x, y int) float64 {
+	x = maxInt(0, minInt(len(grid[0])-1, x))
+	y = maxInt(0, minInt(len(grid)-1, y))
+	return grid[y][x]
 }
 
 func clamp01(value float64) float64 {

--- a/internal/ascii/ascii_test.go
+++ b/internal/ascii/ascii_test.go
@@ -105,6 +105,7 @@ func TestRenderImageSeparatesFillTextFromToneCharset(t *testing.T) {
 		Mode:        domain.ASCIIModeFill,
 		ToneCharset: "@ ",
 		FillText:    "HI",
+		FillFont:    domain.FillFontPlain,
 		Density:     4,
 	})
 	if err != nil {
@@ -114,11 +115,58 @@ func TestRenderImageSeparatesFillTextFromToneCharset(t *testing.T) {
 	if art.FillText != "HI" {
 		t.Fatalf("art.FillText = %q, want %q", art.FillText, "HI")
 	}
+	if art.FillFont != domain.FillFontPlain {
+		t.Fatalf("art.FillFont = %q, want %q", art.FillFont, domain.FillFontPlain)
+	}
 	if art.Charset != "@ " {
 		t.Fatalf("art.Charset = %q, want %q", art.Charset, "@ ")
 	}
 	if !strings.Contains(art.String(), "H") || !strings.Contains(art.String(), "I") {
 		t.Fatalf("expected fill text glyphs in art, got %q", art.String())
+	}
+}
+
+func TestRenderImageRepeatFillFontRepeatsRowPattern(t *testing.T) {
+	img := twoToneImage()
+
+	art, err := RenderImage(img, domain.ASCIIOptions{
+		Mode:      domain.ASCIIModeFill,
+		FillText:  "HI",
+		FillFont:  domain.FillFontRepeat,
+		Density:   4,
+		Threshold: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("RenderImage() error = %v", err)
+	}
+
+	if got := art.Lines[0]; got != "HI  " {
+		t.Fatalf("art.Lines[0] = %q, want %q", got, "HI  ")
+	}
+	if got := art.Lines[1]; got != "HI  " {
+		t.Fatalf("art.Lines[1] = %q, want %q", got, "HI  ")
+	}
+}
+
+func TestRenderImageBlockFillFontProducesBlockPattern(t *testing.T) {
+	img := twoToneImage()
+
+	art, err := RenderImage(img, domain.ASCIIOptions{
+		Mode:      domain.ASCIIModeFill,
+		FillText:  "A",
+		FillFont:  domain.FillFontBlock,
+		Density:   10,
+		Threshold: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("RenderImage() error = %v", err)
+	}
+
+	if !strings.Contains(art.String(), "AAA") {
+		t.Fatalf("expected block letter pattern in art, got %q", art.String())
+	}
+	if !strings.Contains(art.String(), "A A") {
+		t.Fatalf("expected hollow block pattern in art, got %q", art.String())
 	}
 }
 

--- a/internal/ascii/ascii_test.go
+++ b/internal/ascii/ascii_test.go
@@ -20,8 +20,8 @@ func TestRenderPathMatchesFixtureOutput(t *testing.T) {
 	}
 
 	art, err := RenderPath(path, domain.ASCIIOptions{
-		Charset: "@ ",
-		Density: 4,
+		ToneCharset: "@ ",
+		Density:     4,
 	})
 	if err != nil {
 		t.Fatalf("RenderPath() error = %v", err)
@@ -42,9 +42,9 @@ func TestRenderImageAppliesThresholdAndInvert(t *testing.T) {
 	img.Set(1, 0, color.NRGBA{R: 208, G: 208, B: 208, A: 255})
 
 	art, err := RenderImage(img, domain.ASCIIOptions{
-		Charset:   "@ ",
-		Density:   2,
-		Threshold: 0.5,
+		ToneCharset: "@ ",
+		Density:     2,
+		Threshold:   0.5,
 	})
 	if err != nil {
 		t.Fatalf("RenderImage() error = %v", err)
@@ -54,10 +54,10 @@ func TestRenderImageAppliesThresholdAndInvert(t *testing.T) {
 	}
 
 	inverted, err := RenderImage(img, domain.ASCIIOptions{
-		Charset:   "@ ",
-		Density:   2,
-		Threshold: 0.5,
-		Invert:    true,
+		ToneCharset: "@ ",
+		Density:     2,
+		Threshold:   0.5,
+		Invert:      true,
 	})
 	if err != nil {
 		t.Fatalf("RenderImage() with invert error = %v", err)
@@ -71,18 +71,20 @@ func TestRenderImageUsesEdgeWeightAndKeepsOutputDeterministic(t *testing.T) {
 	img := checkerImage()
 
 	first, err := RenderImage(img, domain.ASCIIOptions{
-		Charset:    "@# ",
-		Density:    6,
-		EdgeWeight: 0.75,
+		Mode:        domain.ASCIIModeOutline,
+		ToneCharset: "@# ",
+		Density:     6,
+		EdgeWeight:  0.75,
 	})
 	if err != nil {
 		t.Fatalf("first RenderImage() error = %v", err)
 	}
 
 	second, err := RenderImage(img, domain.ASCIIOptions{
-		Charset:    "@# ",
-		Density:    6,
-		EdgeWeight: 0.75,
+		Mode:        domain.ASCIIModeOutline,
+		ToneCharset: "@# ",
+		Density:     6,
+		EdgeWeight:  0.75,
 	})
 	if err != nil {
 		t.Fatalf("second RenderImage() error = %v", err)
@@ -93,6 +95,60 @@ func TestRenderImageUsesEdgeWeightAndKeepsOutputDeterministic(t *testing.T) {
 	}
 	if first.Width != 6 || first.Height < 1 {
 		t.Fatalf("unexpected dimensions %dx%d", first.Width, first.Height)
+	}
+}
+
+func TestRenderImageSeparatesFillTextFromToneCharset(t *testing.T) {
+	img := twoToneImage()
+
+	art, err := RenderImage(img, domain.ASCIIOptions{
+		Mode:        domain.ASCIIModeFill,
+		ToneCharset: "@ ",
+		FillText:    "HI",
+		Density:     4,
+	})
+	if err != nil {
+		t.Fatalf("RenderImage() error = %v", err)
+	}
+
+	if art.FillText != "HI" {
+		t.Fatalf("art.FillText = %q, want %q", art.FillText, "HI")
+	}
+	if art.Charset != "@ " {
+		t.Fatalf("art.Charset = %q, want %q", art.Charset, "@ ")
+	}
+	if !strings.Contains(art.String(), "H") || !strings.Contains(art.String(), "I") {
+		t.Fatalf("expected fill text glyphs in art, got %q", art.String())
+	}
+}
+
+func TestRenderImageRequiresFillTextForVectorMode(t *testing.T) {
+	_, err := RenderImage(twoToneImage(), domain.ASCIIOptions{
+		Mode:    domain.ASCIIModeVector,
+		Density: 4,
+	})
+	if err == nil {
+		t.Fatal("expected missing fill text error")
+	}
+}
+
+func TestExtractContourSegmentsReturnsRankedSegments(t *testing.T) {
+	art, err := RenderImage(checkerImage(), domain.ASCIIOptions{
+		Mode:        domain.ASCIIModeOutline,
+		ToneCharset: "@# ",
+		Density:     8,
+		EdgeWeight:  1.0,
+	})
+	if err != nil {
+		t.Fatalf("RenderImage() error = %v", err)
+	}
+
+	segments := ExtractContourSegments(art, 0.2)
+	if len(segments) == 0 {
+		t.Fatal("expected contour segments")
+	}
+	if segments[0].Weight <= 0 {
+		t.Fatalf("segment weight = %f", segments[0].Weight)
 	}
 }
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -52,6 +52,14 @@ const (
 	DitherModeFloyd DitherMode = "floyd"
 )
 
+type FillFont string
+
+const (
+	FillFontPlain  FillFont = "plain"
+	FillFontRepeat FillFont = "repeat"
+	FillFontBlock  FillFont = "block"
+)
+
 type SlotType string
 
 const (
@@ -133,6 +141,7 @@ type ASCIIOptions struct {
 	Charset       string     `yaml:"charset,omitempty"`
 	ToneCharset   string     `yaml:"tone_charset,omitempty"`
 	FillText      string     `yaml:"fill_text,omitempty"`
+	FillFont      FillFont   `yaml:"fill_font,omitempty"`
 	Density       int        `yaml:"density,omitempty"`
 	Threshold     float64    `yaml:"threshold,omitempty"`
 	Contrast      float64    `yaml:"contrast,omitempty"`
@@ -156,6 +165,13 @@ func (o ASCIIOptions) EffectiveToneCharset() string {
 		return o.ToneCharset
 	}
 	return o.Charset
+}
+
+func (o ASCIIOptions) EffectiveFillFont() FillFont {
+	if o.FillFont == "" {
+		return FillFontPlain
+	}
+	return o.FillFont
 }
 
 type Template struct {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -35,6 +35,23 @@ const (
 	RenderModeASCII   RenderMode = "ascii"
 )
 
+type ASCIIMode string
+
+const (
+	ASCIIModeTone    ASCIIMode = "tone"
+	ASCIIModeOutline ASCIIMode = "outline"
+	ASCIIModeFill    ASCIIMode = "fill"
+	ASCIIModeHybrid  ASCIIMode = "hybrid"
+	ASCIIModeVector  ASCIIMode = "vector"
+)
+
+type DitherMode string
+
+const (
+	DitherModeOff   DitherMode = "off"
+	DitherModeFloyd DitherMode = "floyd"
+)
+
 type SlotType string
 
 const (
@@ -112,12 +129,33 @@ type ExportOptions struct {
 }
 
 type ASCIIOptions struct {
-	Charset    string  `yaml:"charset,omitempty"`
-	Density    int     `yaml:"density,omitempty"`
-	Threshold  float64 `yaml:"threshold,omitempty"`
-	Contrast   float64 `yaml:"contrast,omitempty"`
-	Invert     bool    `yaml:"invert,omitempty"`
-	EdgeWeight float64 `yaml:"edge_weight,omitempty"`
+	Mode          ASCIIMode  `yaml:"mode,omitempty"`
+	Charset       string     `yaml:"charset,omitempty"`
+	ToneCharset   string     `yaml:"tone_charset,omitempty"`
+	FillText      string     `yaml:"fill_text,omitempty"`
+	Density       int        `yaml:"density,omitempty"`
+	Threshold     float64    `yaml:"threshold,omitempty"`
+	Contrast      float64    `yaml:"contrast,omitempty"`
+	Gamma         float64    `yaml:"gamma,omitempty"`
+	Invert        bool       `yaml:"invert,omitempty"`
+	EdgeWeight    float64    `yaml:"edge_weight,omitempty"`
+	EdgeThreshold float64    `yaml:"edge_threshold,omitempty"`
+	Dither        DitherMode `yaml:"dither,omitempty"`
+	CellAspect    float64    `yaml:"cell_aspect,omitempty"`
+}
+
+func (o ASCIIOptions) EffectiveMode() ASCIIMode {
+	if o.Mode == "" {
+		return ASCIIModeTone
+	}
+	return o.Mode
+}
+
+func (o ASCIIOptions) EffectiveToneCharset() string {
+	if o.ToneCharset != "" {
+		return o.ToneCharset
+	}
+	return o.Charset
 }
 
 type Template struct {

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -83,6 +83,9 @@ func (p Project) Validate() error {
 	if p.Options.ASCII.Dither != "" && !p.Options.ASCII.Dither.valid() {
 		errs = errs.add("options.ascii.dither", "must be off or floyd")
 	}
+	if p.Options.ASCII.FillFont != "" && !p.Options.ASCII.FillFont.valid() {
+		errs = errs.add("options.ascii.fill_font", "must be plain, repeat, or block")
+	}
 	if p.Options.ASCII.CellAspect < 0 {
 		errs = errs.add("options.ascii.cell_aspect", "must be greater than or equal to 0")
 	}
@@ -255,6 +258,15 @@ func (m ASCIIMode) valid() bool {
 func (m DitherMode) valid() bool {
 	switch m {
 	case DitherModeOff, DitherModeFloyd:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f FillFont) valid() bool {
+	switch f {
+	case FillFontPlain, FillFontRepeat, FillFontBlock:
 		return true
 	default:
 		return false

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -59,6 +59,9 @@ func (p Project) Validate() error {
 	if p.Options.RenderMode != "" && !p.Options.RenderMode.valid() {
 		errs = errs.add("options.render_mode", "must be compose or ascii")
 	}
+	if p.Options.ASCII.Mode != "" && !p.Options.ASCII.Mode.valid() {
+		errs = errs.add("options.ascii.mode", "must be tone, outline, fill, hybrid, or vector")
+	}
 	if p.Options.ASCII.Density < 0 {
 		errs = errs.add("options.ascii.density", "must be greater than or equal to 0")
 	}
@@ -68,8 +71,24 @@ func (p Project) Validate() error {
 	if p.Options.ASCII.Contrast < 0 {
 		errs = errs.add("options.ascii.contrast", "must be greater than or equal to 0")
 	}
+	if p.Options.ASCII.Gamma < 0 {
+		errs = errs.add("options.ascii.gamma", "must be greater than or equal to 0")
+	}
 	if p.Options.ASCII.EdgeWeight < 0 || p.Options.ASCII.EdgeWeight > 1 {
 		errs = errs.add("options.ascii.edge_weight", "must be between 0 and 1")
+	}
+	if p.Options.ASCII.EdgeThreshold < 0 || p.Options.ASCII.EdgeThreshold > 1 {
+		errs = errs.add("options.ascii.edge_threshold", "must be between 0 and 1")
+	}
+	if p.Options.ASCII.Dither != "" && !p.Options.ASCII.Dither.valid() {
+		errs = errs.add("options.ascii.dither", "must be off or floyd")
+	}
+	if p.Options.ASCII.CellAspect < 0 {
+		errs = errs.add("options.ascii.cell_aspect", "must be greater than or equal to 0")
+	}
+	mode := p.Options.ASCII.EffectiveMode()
+	if (mode == ASCIIModeFill || mode == ASCIIModeHybrid || mode == ASCIIModeVector) && strings.TrimSpace(p.Options.ASCII.FillText) == "" {
+		errs = errs.add("options.ascii.fill_text", "is required for fill, hybrid, and vector modes")
 	}
 	if p.Export.Format != "" && !p.Export.Format.valid() {
 		errs = errs.add("export.format", "must be one of pdf, png, or svg")
@@ -218,6 +237,24 @@ func (f ExportFormat) valid() bool {
 func (m RenderMode) valid() bool {
 	switch m {
 	case RenderModeCompose, RenderModeASCII:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m ASCIIMode) valid() bool {
+	switch m {
+	case ASCIIModeTone, ASCIIModeOutline, ASCIIModeFill, ASCIIModeHybrid, ASCIIModeVector:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m DitherMode) valid() bool {
+	switch m {
+	case DitherModeOff, DitherModeFloyd:
 		return true
 	default:
 		return false

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -65,10 +65,15 @@ func TestProjectValidateRejectsInvalidASCIIOptions(t *testing.T) {
 		Options: ProjectOptions{
 			RenderMode: "vectorized",
 			ASCII: ASCIIOptions{
-				Density:    -1,
-				Threshold:  1.2,
-				Contrast:   -0.5,
-				EdgeWeight: 2,
+				Mode:          "posterized",
+				Density:       -1,
+				Threshold:     1.2,
+				Contrast:      -0.5,
+				Gamma:         -1,
+				EdgeWeight:    2,
+				EdgeThreshold: 2,
+				Dither:        "blue-noise",
+				CellAspect:    -0.2,
 			},
 		},
 	}
@@ -80,10 +85,15 @@ func TestProjectValidateRejectsInvalidASCIIOptions(t *testing.T) {
 
 	for _, fragment := range []string{
 		"options.render_mode: must be compose or ascii",
+		"options.ascii.mode: must be tone, outline, fill, hybrid, or vector",
 		"options.ascii.density: must be greater than or equal to 0",
 		"options.ascii.threshold: must be between 0 and 1",
 		"options.ascii.contrast: must be greater than or equal to 0",
+		"options.ascii.gamma: must be greater than or equal to 0",
 		"options.ascii.edge_weight: must be between 0 and 1",
+		"options.ascii.edge_threshold: must be between 0 and 1",
+		"options.ascii.dither: must be off or floyd",
+		"options.ascii.cell_aspect: must be greater than or equal to 0",
 	} {
 		if !strings.Contains(err.Error(), fragment) {
 			t.Fatalf("expected %q in validation error, got %q", fragment, err.Error())
@@ -102,17 +112,48 @@ func TestProjectValidateAcceptsASCIIOptions(t *testing.T) {
 		Options: ProjectOptions{
 			RenderMode: RenderModeASCII,
 			ASCII: ASCIIOptions{
-				Charset:    "@# ",
-				Density:    96,
-				Threshold:  0.42,
-				Contrast:   1.25,
-				Invert:     true,
-				EdgeWeight: 0.35,
+				Mode:          ASCIIModeHybrid,
+				ToneCharset:   "@# ",
+				FillText:      "Happy Birthday",
+				Density:       96,
+				Threshold:     0.42,
+				Contrast:      1.25,
+				Gamma:         1.1,
+				Invert:        true,
+				EdgeWeight:    0.35,
+				EdgeThreshold: 0.4,
+				Dither:        DitherModeFloyd,
+				CellAspect:    0.5,
 			},
 		},
 	}
 
 	if err := project.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestProjectValidateRequiresFillTextForFillModes(t *testing.T) {
+	project := Project{
+		Version:  CurrentSchemaVersion,
+		Template: "classic-letter-a4",
+		Page: ProjectPage{
+			Size:        PageSizeA4,
+			Orientation: OrientationPortrait,
+		},
+		Options: ProjectOptions{
+			RenderMode: RenderModeASCII,
+			ASCII: ASCIIOptions{
+				Mode: ASCIIModeVector,
+			},
+		},
+	}
+
+	err := project.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "options.ascii.fill_text: is required for fill, hybrid, and vector modes") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -73,6 +73,7 @@ func TestProjectValidateRejectsInvalidASCIIOptions(t *testing.T) {
 				EdgeWeight:    2,
 				EdgeThreshold: 2,
 				Dither:        "blue-noise",
+				FillFont:      "shadow",
 				CellAspect:    -0.2,
 			},
 		},
@@ -93,6 +94,7 @@ func TestProjectValidateRejectsInvalidASCIIOptions(t *testing.T) {
 		"options.ascii.edge_weight: must be between 0 and 1",
 		"options.ascii.edge_threshold: must be between 0 and 1",
 		"options.ascii.dither: must be off or floyd",
+		"options.ascii.fill_font: must be plain, repeat, or block",
 		"options.ascii.cell_aspect: must be greater than or equal to 0",
 	} {
 		if !strings.Contains(err.Error(), fragment) {
@@ -115,6 +117,7 @@ func TestProjectValidateAcceptsASCIIOptions(t *testing.T) {
 				Mode:          ASCIIModeHybrid,
 				ToneCharset:   "@# ",
 				FillText:      "Happy Birthday",
+				FillFont:      FillFontBlock,
 				Density:       96,
 				Threshold:     0.42,
 				Contrast:      1.25,

--- a/internal/export/ascii.go
+++ b/internal/export/ascii.go
@@ -3,6 +3,7 @@ package export
 import (
 	"fmt"
 	"image/color"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,9 @@ func WriteASCII(composition *render.ASCIIComposition, options ASCIIExportOptions
 
 	switch options.Format {
 	case ASCIIFormatTXT:
+		if composition.Options.EffectiveMode() == domain.ASCIIModeVector {
+			return "", fmt.Errorf("vector mode supports PDF export only")
+		}
 		if err := writeASCIITXT(composition, out); err != nil {
 			return "", err
 		}
@@ -119,6 +123,14 @@ func writeASCIITXT(composition *render.ASCIIComposition, out string) error {
 }
 
 func writeASCIIPDF(composition *render.ASCIIComposition, out string, options ASCIIExportOptions) error {
+	if composition.Options.EffectiveMode() == domain.ASCIIModeVector {
+		return writeVectorASCIIPDF(composition, out, options)
+	}
+
+	return writeRasterASCIIPDF(composition, out, options)
+}
+
+func writeRasterASCIIPDF(composition *render.ASCIIComposition, out string, options ASCIIExportOptions) error {
 	layout, err := resolveASCIILayout(composition, options)
 	if err != nil {
 		return err
@@ -138,6 +150,86 @@ func writeASCIIPDF(composition *render.ASCIIComposition, out string, options ASC
 	for index, line := range composition.Art.Lines {
 		y := topY - float64(index)*layout.lineStepMM
 		ctx.DrawText(layout.marginMM, y, canvas.NewTextLine(layout.face, line, canvas.Left))
+	}
+
+	pdf := pdfrenderer.New(
+		file,
+		float64(page.Dimensions.WidthMM),
+		float64(page.Dimensions.HeightMM),
+		nil,
+	)
+	surface.RenderTo(pdf)
+	if err := pdf.Close(); err != nil {
+		return fmt.Errorf("finalize ascii pdf %q: %w", out, err)
+	}
+
+	return nil
+}
+
+func writeVectorASCIIPDF(composition *render.ASCIIComposition, out string, options ASCIIExportOptions) error {
+	if len(composition.Segments) == 0 {
+		return writeRasterASCIIPDF(composition, out, options)
+	}
+
+	fillText := composition.Options.FillText
+	if strings.TrimSpace(fillText) == "" {
+		fillText = composition.Art.FillText
+	}
+	fillText = strings.TrimSpace(fillText)
+	if fillText == "" {
+		return fmt.Errorf("vector mode requires fill text")
+	}
+
+	file, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("create ascii pdf %q: %w", out, err)
+	}
+	defer file.Close()
+
+	page := composition.Page
+	marginMM := options.MarginMM
+	if marginMM <= 0 {
+		marginMM = defaultASCIIMarginMM
+	}
+	safeWidth := float64(page.Dimensions.WidthMM) - marginMM*2
+	safeHeight := float64(page.Dimensions.HeightMM) - marginMM*2
+	if safeWidth <= 0 || safeHeight <= 0 {
+		return fmt.Errorf("ascii export margin %.2fmm leaves no printable area", marginMM)
+	}
+
+	fontSizePt := options.FontSizePt
+	if fontSizePt <= 0 {
+		fontSizePt = 10
+	}
+	face, err := monoFace(fontSizePt)
+	if err != nil {
+		return err
+	}
+
+	surface := canvas.New(float64(page.Dimensions.WidthMM), float64(page.Dimensions.HeightMM))
+	ctx := canvas.NewContext(surface)
+
+	maxSegments := minInt(48, len(composition.Segments))
+	for _, segment := range composition.Segments[:maxSegments] {
+		x1, y1 := segmentToCanvasPoint(segment.X1, segment.Y1, composition.Art.Width, composition.Art.Height, marginMM, safeWidth, safeHeight)
+		x2, y2 := segmentToCanvasPoint(segment.X2, segment.Y2, composition.Art.Width, composition.Art.Height, marginMM, safeWidth, safeHeight)
+
+		length := math.Hypot(x2-x1, y2-y1)
+		if length < 8 {
+			continue
+		}
+
+		text := repeatTextToLength(fillText, face, length)
+		if text == "" {
+			continue
+		}
+
+		angle := math.Atan2(y2-y1, x2-x1) * 180 / math.Pi
+		ctx.Push()
+		ctx.Translate(x1, y1)
+		ctx.Rotate(angle)
+		ctx.DrawText(0, 0, canvas.NewTextLine(face, text, canvas.Left))
+		ctx.Pop()
 	}
 
 	pdf := pdfrenderer.New(
@@ -236,6 +328,45 @@ func asciiLineWidth(face *canvas.FontFace, columns int) float64 {
 	return sample.Bounds().W()
 }
 
+func repeatTextToLength(fillText string, face *canvas.FontFace, maxWidth float64) string {
+	fillText = strings.TrimSpace(fillText)
+	if fillText == "" || maxWidth <= 0 {
+		return ""
+	}
+
+	seed := fillText
+	if !strings.Contains(seed, " ") {
+		seed += " "
+	}
+
+	var builder strings.Builder
+	for builder.Len() < 8 || canvas.NewTextLine(face, builder.String(), canvas.Left).Bounds().W() < maxWidth {
+		builder.WriteString(seed)
+		if builder.Len() > 4096 {
+			break
+		}
+	}
+
+	text := strings.TrimSpace(builder.String())
+	if text == "" {
+		return fillText
+	}
+
+	runes := []rune(text)
+	for len(runes) > 1 && canvas.NewTextLine(face, string(runes), canvas.Left).Bounds().W() > maxWidth {
+		runes = runes[:len(runes)-1]
+	}
+	return strings.TrimSpace(string(runes))
+}
+
+func segmentToCanvasPoint(x, y float64, artWidth, artHeight int, marginMM, safeWidth, safeHeight float64) (float64, float64) {
+	nx := x / float64(maxInt(1, artWidth))
+	ny := y / float64(maxInt(1, artHeight))
+	canvasX := marginMM + nx*safeWidth
+	canvasY := marginMM + safeHeight - ny*safeHeight
+	return canvasX, canvasY
+}
+
 func monoFace(sizePt float64) (*canvas.FontFace, error) {
 	if err := ensureMonoFamily(); err != nil {
 		return nil, err
@@ -269,4 +400,18 @@ func (f ASCIIFormat) valid() bool {
 	default:
 		return false
 	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/export/ascii_test.go
+++ b/internal/export/ascii_test.go
@@ -22,8 +22,8 @@ func TestComposeAndWriteASCIIExportsTXT(t *testing.T) {
 		Size:        domain.PageSizeA4,
 		Orientation: domain.OrientationPortrait,
 	}, imagePath, domain.ASCIIOptions{
-		Charset: "@ ",
-		Density: 4,
+		ToneCharset: "@ ",
+		Density:     4,
 	}, ASCIIExportOptions{
 		Format: ASCIIFormatTXT,
 		Out:    filepath.Join(tmpDir, "ascii-output"),
@@ -107,6 +107,38 @@ func TestNormalizeASCIIOutputPathRejectsMismatchedExtension(t *testing.T) {
 	}
 }
 
+func TestWriteASCIIRejectsTXTForVectorMode(t *testing.T) {
+	composition := sampleASCIIComposition(domain.ProjectPage{
+		Size:        domain.PageSizeA4,
+		Orientation: domain.OrientationPortrait,
+	})
+	composition.Options.Mode = domain.ASCIIModeVector
+
+	if _, err := WriteASCII(composition, ASCIIExportOptions{
+		Format: ASCIIFormatTXT,
+		Out:    filepath.Join(t.TempDir(), "vector.txt"),
+	}); err == nil {
+		t.Fatal("expected vector TXT export to fail")
+	}
+}
+
+func TestWriteASCIIExportsVectorPDFBeta(t *testing.T) {
+	composition := sampleASCIIComposition(domain.ProjectPage{
+		Size:        domain.PageSizeA5,
+		Orientation: domain.OrientationPortrait,
+	})
+	composition.Options.Mode = domain.ASCIIModeVector
+
+	out, err := WriteASCII(composition, ASCIIExportOptions{
+		Format: ASCIIFormatPDF,
+		Out:    filepath.Join(t.TempDir(), "vector-beta.pdf"),
+	})
+	if err != nil {
+		t.Fatalf("WriteASCII() error = %v", err)
+	}
+	assertFileExists(t, out)
+}
+
 func sampleASCIIComposition(page domain.ProjectPage) *render.ASCIIComposition {
 	dimensions, _ := domain.ISOPage(page.Size, page.Orientation)
 
@@ -117,17 +149,25 @@ func sampleASCIIComposition(page domain.ProjectPage) *render.ASCIIComposition {
 			Dimensions:  dimensions,
 		},
 		Options: domain.ASCIIOptions{
-			Charset: "@ ",
-			Density: 4,
+			Mode:        domain.ASCIIModeHybrid,
+			ToneCharset: "@ ",
+			FillText:    "HELLO WORLD",
+			Density:     4,
 		},
 		Art: asciipkg.Art{
-			Width:   4,
-			Height:  2,
-			Charset: "@ ",
+			Mode:     domain.ASCIIModeHybrid,
+			Width:    4,
+			Height:   2,
+			Charset:  "@ ",
+			FillText: "HELLO WORLD",
 			Lines: []string{
 				"@@  ",
 				"@@  ",
 			},
+		},
+		Segments: []asciipkg.Segment{
+			{X1: 0.5, Y1: 0.5, X2: 3.5, Y2: 0.5, Weight: 0.9},
+			{X1: 0.5, Y1: 1.5, X2: 3.5, Y2: 1.5, Weight: 0.8},
 		},
 	}
 }

--- a/internal/render/ascii.go
+++ b/internal/render/ascii.go
@@ -13,6 +13,7 @@ type ASCIIComposition struct {
 	Page      Page
 	Options   domain.ASCIIOptions
 	Art       asciipkg.Art
+	Segments  []asciipkg.Segment
 }
 
 func ComposeASCII(page domain.ProjectPage, imagePath string, options domain.ASCIIOptions) (*ASCIIComposition, error) {
@@ -37,7 +38,8 @@ func ComposeASCII(page domain.ProjectPage, imagePath string, options domain.ASCI
 			Orientation: page.Orientation,
 			Dimensions:  dimensions,
 		},
-		Options: options,
-		Art:     art,
+		Options:  options,
+		Art:      art,
+		Segments: asciipkg.ExtractContourSegments(art, options.EdgeThreshold),
 	}, nil
 }

--- a/internal/render/ascii_test.go
+++ b/internal/render/ascii_test.go
@@ -18,8 +18,9 @@ func TestComposeASCIIBuildsPageAwareComposition(t *testing.T) {
 		Size:        domain.PageSizeA5,
 		Orientation: domain.OrientationLandscape,
 	}, imagePath, domain.ASCIIOptions{
-		Charset: "@ ",
-		Density: 4,
+		Mode:        domain.ASCIIModeOutline,
+		ToneCharset: "@ ",
+		Density:     4,
 	})
 	if err != nil {
 		t.Fatalf("ComposeASCII() error = %v", err)
@@ -36,6 +37,9 @@ func TestComposeASCIIBuildsPageAwareComposition(t *testing.T) {
 	}
 	if composition.ImagePath != imagePath {
 		t.Fatalf("image path = %q, want %q", composition.ImagePath, imagePath)
+	}
+	if len(composition.Segments) == 0 {
+		t.Fatal("expected contour segments")
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -32,6 +32,9 @@ var commandCatalog = []string{
 	"/image ",
 	"/fill-file ",
 	`/fill-text "Happy Birthday"`,
+	"/fill-font plain",
+	"/fill-font repeat",
+	"/fill-font block",
 	"/mode tone",
 	"/mode outline",
 	"/mode fill",
@@ -113,6 +116,7 @@ func newDraft() Draft {
 		},
 		ASCII: domain.ASCIIOptions{
 			Mode:       domain.ASCIIModeTone,
+			FillFont:   domain.FillFontPlain,
 			Density:    80,
 			Dither:     domain.DitherModeOff,
 			CellAspect: asciiDefaultCellAspect(),
@@ -127,6 +131,7 @@ func (d Draft) EffectiveASCIIOptions() domain.ASCIIOptions {
 	if strings.TrimSpace(options.FillText) == "" {
 		options.FillText = normalizeFillText(d.Text)
 	}
+	options.FillFont = options.EffectiveFillFont()
 	return options
 }
 
@@ -145,6 +150,10 @@ func (d Draft) FillLabel() string {
 		return summarizeText(normalizeFillText(d.Text))
 	}
 	return "not set"
+}
+
+func (d Draft) FillFontLabel() string {
+	return string(d.EffectiveASCIIOptions().EffectiveFillFont())
 }
 
 type slashCommand struct {
@@ -411,7 +420,7 @@ func tokenizeCommand(input string) ([]string, error) {
 func (m *Model) applyCommand(command slashCommand) error {
 	switch command.Name {
 	case "help":
-		m.setStatus("Commands: /image /fill-file /fill-text /mode /tone-charset /density /threshold /gamma /edge-threshold /dither /cell-aspect /export", false)
+		m.setStatus("Commands: /image /fill-file /fill-text /fill-font /mode /tone-charset /density /threshold /gamma /edge-threshold /dither /cell-aspect /export", false)
 		return nil
 	case "image":
 		if len(command.Args) != 1 {
@@ -447,6 +456,20 @@ func (m *Model) applyCommand(command slashCommand) error {
 		m.draft.ASCII.FillText = ""
 		m.refreshPreview()
 		m.setStatus("Fill text updated.", false)
+		return nil
+	case "fill-font", "font":
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /fill-font <plain|repeat|block>")
+		}
+		fillFont := domain.FillFont(strings.ToLower(command.Args[0]))
+		switch fillFont {
+		case domain.FillFontPlain, domain.FillFontRepeat, domain.FillFontBlock:
+			m.draft.ASCII.FillFont = fillFont
+		default:
+			return fmt.Errorf("fill-font must be plain, repeat, or block")
+		}
+		m.refreshPreview()
+		m.setStatus(fmt.Sprintf("Fill font set to %s.", fillFont), false)
 		return nil
 	case "mode":
 		if len(command.Args) != 1 {
@@ -1049,6 +1072,7 @@ func (m Model) renderHeaderBody() string {
 	sources := []string{
 		fmt.Sprintf("image %s", summarizeText(m.draft.ImagePath)),
 		fmt.Sprintf("fill %s", m.draft.FillLabel()),
+		fmt.Sprintf("font %s", m.draft.FillFontLabel()),
 		fmt.Sprintf("tone %s", m.draft.ToneLabel()),
 		fmt.Sprintf("dither %s", effectiveDither(m.draft.ASCII.Dither)),
 	}
@@ -1118,8 +1142,9 @@ func (m Model) previewContent(width int) string {
 			"",
 			"1. /image ./test.png",
 			"2. /fill-file ./test.txt",
-			"3. /mode hybrid",
-			"4. /export pdf ./exports/out.pdf",
+			"3. /fill-font block",
+			"4. /mode hybrid",
+			"5. /export pdf ./exports/out.pdf",
 			"",
 			"Tab completes matching commands and file paths.",
 		}
@@ -1152,7 +1177,7 @@ func (m Model) renderPromptPane(width int) string {
 		lines = append(lines, mutedStyle.Render("picker"), mutedStyle.Render("  no suggestions"))
 	}
 
-	lines = append(lines, mutedStyle.Width(width).Render(`examples: /image test  ·  /fill-file test  ·  /mode hybrid  ·  /tone-charset "@%#*+=-:. "`))
+	lines = append(lines, mutedStyle.Width(width).Render(`examples: /image test  ·  /fill-file test  ·  /fill-font block  ·  /mode hybrid`))
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -30,14 +30,22 @@ var (
 
 var commandCatalog = []string{
 	"/image ",
-	"/text-file ",
-	`/text "Happy Birthday"`,
-	"/mode ascii",
+	"/fill-file ",
+	`/fill-text "Happy Birthday"`,
+	"/mode tone",
+	"/mode outline",
+	"/mode fill",
+	"/mode hybrid",
+	"/mode vector",
 	"/size A4",
 	"/orientation portrait",
-	`/charset "@#* ."`,
+	`/tone-charset "@#* ."`,
 	"/density 96",
 	"/threshold 0.42",
+	"/gamma 1.20",
+	"/edge-threshold 0.35",
+	"/dither floyd",
+	"/cell-aspect 0.48",
 	"/invert on",
 	"/export pdf ./exports/out.pdf",
 	"/export txt ./exports/out.txt",
@@ -104,7 +112,10 @@ func newDraft() Draft {
 			Orientation: domain.OrientationPortrait,
 		},
 		ASCII: domain.ASCIIOptions{
-			Density: 80,
+			Mode:       domain.ASCIIModeTone,
+			Density:    80,
+			Dither:     domain.DitherModeOff,
+			CellAspect: asciiDefaultCellAspect(),
 		},
 		ExportFormat: exportpkg.ASCIIFormatPDF,
 		ExportOut:    suggestedExportPath(exportpkg.ASCIIFormatPDF),
@@ -113,22 +124,27 @@ func newDraft() Draft {
 
 func (d Draft) EffectiveASCIIOptions() domain.ASCIIOptions {
 	options := d.ASCII
-	if strings.TrimSpace(options.Charset) == "" {
-		if derived := normalizeGlyphSource(d.Text); derived != "" {
-			options.Charset = derived
-		}
+	if strings.TrimSpace(options.FillText) == "" {
+		options.FillText = normalizeFillText(d.Text)
 	}
 	return options
 }
 
-func (d Draft) GlyphSourceLabel() string {
-	if strings.TrimSpace(d.ASCII.Charset) != "" {
-		return "explicit charset"
+func (d Draft) ToneLabel() string {
+	if strings.TrimSpace(d.ASCII.ToneCharset) != "" || strings.TrimSpace(d.ASCII.Charset) != "" {
+		return summarizeText(d.EffectiveASCIIOptions().EffectiveToneCharset())
+	}
+	return "default ramp"
+}
+
+func (d Draft) FillLabel() string {
+	if strings.TrimSpace(d.TextFile) != "" {
+		return summarizeText(d.TextFile)
 	}
 	if strings.TrimSpace(d.Text) != "" {
-		return "lettering-derived"
+		return summarizeText(normalizeFillText(d.Text))
 	}
-	return "default ascii ramp"
+	return "not set"
 }
 
 type slashCommand struct {
@@ -395,7 +411,7 @@ func tokenizeCommand(input string) ([]string, error) {
 func (m *Model) applyCommand(command slashCommand) error {
 	switch command.Name {
 	case "help":
-		m.setStatus("Commands: /image /text-file /text /size /orientation /charset /density /threshold /invert /export", false)
+		m.setStatus("Commands: /image /fill-file /fill-text /mode /tone-charset /density /threshold /gamma /edge-threshold /dither /cell-aspect /export", false)
 		return nil
 	case "image":
 		if len(command.Args) != 1 {
@@ -408,35 +424,47 @@ func (m *Model) applyCommand(command slashCommand) error {
 		m.refreshPreview()
 		m.setStatus(fmt.Sprintf("Image set to %s.", command.Args[0]), false)
 		return nil
-	case "text-file":
+	case "fill-file", "text-file":
 		if len(command.Args) != 1 {
-			return fmt.Errorf("usage: /text-file <path>")
+			return fmt.Errorf("usage: /fill-file <path>")
 		}
 		body, err := importTextFile(command.Args[0])
 		if err != nil {
 			return err
 		}
 		m.draft.TextFile = command.Args[0]
-		m.draft.Text = body
+		m.draft.Text = normalizeFillText(body)
+		m.draft.ASCII.FillText = ""
 		m.refreshPreview()
-		m.setStatus(fmt.Sprintf("Loaded lettering text from %s.", command.Args[0]), false)
+		m.setStatus(fmt.Sprintf("Loaded fill text from %s.", command.Args[0]), false)
 		return nil
-	case "text":
+	case "fill-text", "text":
 		if len(command.Args) == 0 {
-			return fmt.Errorf("usage: /text <lettering>")
+			return fmt.Errorf("usage: /fill-text <lettering>")
 		}
-		m.draft.Text = strings.Join(command.Args, " ")
+		m.draft.Text = normalizeFillText(strings.Join(command.Args, " "))
 		m.draft.TextFile = ""
+		m.draft.ASCII.FillText = ""
 		m.refreshPreview()
-		m.setStatus("Lettering text updated.", false)
+		m.setStatus("Fill text updated.", false)
 		return nil
 	case "mode":
-		if len(command.Args) != 1 || strings.ToLower(command.Args[0]) != string(domain.RenderModeASCII) {
-			return fmt.Errorf("usage: /mode ascii")
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /mode <tone|outline|fill|hybrid|vector>")
 		}
 		m.draft.Mode = domain.RenderModeASCII
+		mode := domain.ASCIIMode(strings.ToLower(command.Args[0]))
+		if mode == "ascii" {
+			mode = domain.ASCIIModeTone
+		}
+		switch mode {
+		case domain.ASCIIModeTone, domain.ASCIIModeOutline, domain.ASCIIModeFill, domain.ASCIIModeHybrid, domain.ASCIIModeVector:
+			m.draft.ASCII.Mode = mode
+		default:
+			return fmt.Errorf("mode must be tone, outline, fill, hybrid, or vector")
+		}
 		m.refreshPreview()
-		m.setStatus("Render mode set to ascii.", false)
+		m.setStatus(fmt.Sprintf("Render mode set to %s.", m.draft.ASCII.Mode), false)
 		return nil
 	case "size":
 		if len(command.Args) != 1 {
@@ -466,13 +494,15 @@ func (m *Model) applyCommand(command slashCommand) error {
 		default:
 			return fmt.Errorf("orientation must be portrait or landscape")
 		}
-	case "charset":
+	case "tone-charset", "charset":
 		if len(command.Args) == 0 {
-			return fmt.Errorf("usage: /charset <glyphs>")
+			return fmt.Errorf("usage: /tone-charset <glyphs>")
 		}
-		m.draft.ASCII.Charset = strings.Join(command.Args, " ")
+		value := strings.Join(command.Args, " ")
+		m.draft.ASCII.ToneCharset = value
+		m.draft.ASCII.Charset = value
 		m.refreshPreview()
-		m.setStatus("Explicit charset updated.", false)
+		m.setStatus("Tone charset updated.", false)
 		return nil
 	case "density":
 		if len(command.Args) != 1 {
@@ -497,6 +527,56 @@ func (m *Model) applyCommand(command slashCommand) error {
 		m.draft.ASCII.Threshold = threshold
 		m.refreshPreview()
 		m.setStatus(fmt.Sprintf("Threshold set to %.2f.", threshold), false)
+		return nil
+	case "gamma":
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /gamma <value>")
+		}
+		gamma, err := strconv.ParseFloat(command.Args[0], 64)
+		if err != nil || gamma <= 0 {
+			return fmt.Errorf("gamma must be greater than 0")
+		}
+		m.draft.ASCII.Gamma = gamma
+		m.refreshPreview()
+		m.setStatus(fmt.Sprintf("Gamma set to %.2f.", gamma), false)
+		return nil
+	case "edge-threshold":
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /edge-threshold <0..1>")
+		}
+		edgeThreshold, err := strconv.ParseFloat(command.Args[0], 64)
+		if err != nil || edgeThreshold < 0 || edgeThreshold > 1 {
+			return fmt.Errorf("edge-threshold must be between 0 and 1")
+		}
+		m.draft.ASCII.EdgeThreshold = edgeThreshold
+		m.refreshPreview()
+		m.setStatus(fmt.Sprintf("Edge threshold set to %.2f.", edgeThreshold), false)
+		return nil
+	case "dither":
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /dither <off|floyd>")
+		}
+		dither := domain.DitherMode(strings.ToLower(command.Args[0]))
+		switch dither {
+		case domain.DitherModeOff, domain.DitherModeFloyd:
+			m.draft.ASCII.Dither = dither
+		default:
+			return fmt.Errorf("dither must be off or floyd")
+		}
+		m.refreshPreview()
+		m.setStatus(fmt.Sprintf("Dither set to %s.", dither), false)
+		return nil
+	case "cell-aspect":
+		if len(command.Args) != 1 {
+			return fmt.Errorf("usage: /cell-aspect <value>")
+		}
+		cellAspect, err := strconv.ParseFloat(command.Args[0], 64)
+		if err != nil || cellAspect <= 0 {
+			return fmt.Errorf("cell-aspect must be greater than 0")
+		}
+		m.draft.ASCII.CellAspect = cellAspect
+		m.refreshPreview()
+		m.setStatus(fmt.Sprintf("Cell aspect set to %.2f.", cellAspect), false)
 		return nil
 	case "invert":
 		if len(command.Args) != 1 {
@@ -635,7 +715,7 @@ func suggestForInput(input, cwd string) []suggestion {
 			return nil
 		}
 		return pathSuggestions(cwd, trimmed, partial, []string{".png", ".jpg", ".jpeg", ".webp"})
-	case "/text-file":
+	case "/fill-file", "/text-file":
 		partial := ""
 		if len(args) > 0 {
 			partial = args[0]
@@ -968,21 +1048,25 @@ func (m *Model) historyNext() {
 func (m Model) renderHeaderBody() string {
 	sources := []string{
 		fmt.Sprintf("image %s", summarizeText(m.draft.ImagePath)),
-		fmt.Sprintf("text %s", summarizeText(m.draft.TextFile)),
-		fmt.Sprintf("glyphs %s", m.draft.GlyphSourceLabel()),
-	}
-	if strings.TrimSpace(m.draft.TextFile) == "" && strings.TrimSpace(m.draft.Text) != "" {
-		sources[1] = fmt.Sprintf("text %s", summarizeText(m.draft.Text))
+		fmt.Sprintf("fill %s", m.draft.FillLabel()),
+		fmt.Sprintf("tone %s", m.draft.ToneLabel()),
+		fmt.Sprintf("dither %s", effectiveDither(m.draft.ASCII.Dither)),
 	}
 
 	lines := []string{
 		headerStyle.Render(">_ letterpress ascii"),
-		mutedStyle.Render(fmt.Sprintf("%s %s  ·  %s  ·  density %d  ·  threshold %s  ·  invert %t",
+		mutedStyle.Render(fmt.Sprintf("%s  ·  %s %s  ·  %s  ·  density %d  ·  threshold %s",
+			strings.ToUpper(string(m.draft.EffectiveASCIIOptions().EffectiveMode())),
 			m.draft.Page.Size,
 			m.draft.Page.Orientation,
 			strings.ToUpper(string(m.draft.ExportFormat)),
 			effectiveDensity(m.draft.ASCII.Density),
 			formatThreshold(m.draft.ASCII.Threshold),
+		)),
+		mutedStyle.Render(fmt.Sprintf("gamma %s  ·  edge %s  ·  aspect %s  ·  invert %t",
+			formatFloatOrDefault(m.draft.ASCII.Gamma, "default"),
+			formatThreshold(m.draft.ASCII.EdgeThreshold),
+			formatFloatOrDefault(m.draft.ASCII.CellAspect, "default"),
 			m.draft.ASCII.Invert,
 		)),
 		mutedStyle.Render(strings.Join(sources, "  ·  ")),
@@ -1033,8 +1117,9 @@ func (m Model) previewContent(width int) string {
 			"No source image configured.",
 			"",
 			"1. /image ./test.png",
-			"2. /text-file ./test.txt",
-			"3. /export txt ./exports/out.txt",
+			"2. /fill-file ./test.txt",
+			"3. /mode hybrid",
+			"4. /export pdf ./exports/out.pdf",
 			"",
 			"Tab completes matching commands and file paths.",
 		}
@@ -1067,7 +1152,7 @@ func (m Model) renderPromptPane(width int) string {
 		lines = append(lines, mutedStyle.Render("picker"), mutedStyle.Render("  no suggestions"))
 	}
 
-	lines = append(lines, mutedStyle.Width(width).Render(`examples: /image test  ·  /text-file test  ·  /export pdf ./exports/out.pdf`))
+	lines = append(lines, mutedStyle.Width(width).Render(`examples: /image test  ·  /fill-file test  ·  /mode hybrid  ·  /tone-charset "@%#*+=-:. "`))
 	return strings.Join(lines, "\n")
 }
 
@@ -1148,24 +1233,21 @@ func validateImageFile(path string) error {
 	return nil
 }
 
-func normalizeGlyphSource(text string) string {
+func normalizeFillText(text string) string {
 	replacer := strings.NewReplacer("\r", " ", "\n", " ", "\t", " ")
 	clean := strings.Join(strings.Fields(replacer.Replace(text)), " ")
-	if clean == "" {
-		return ""
+	if len([]rune(clean)) > 256 {
+		return string([]rune(clean)[:256])
 	}
-	runes := []rune(clean)
-	if len(runes) > 128 {
-		runes = runes[:128]
-	}
-	if len(runes) == 1 {
-		return string(append(runes, ' '))
-	}
-	return string(runes)
+	return clean
 }
 
 func suggestedExportPath(format exportpkg.ASCIIFormat) string {
 	return filepath.Join("exports", "ascii-art."+string(format))
+}
+
+func asciiDefaultCellAspect() float64 {
+	return asciipkg.DefaultCellAspectRatio
 }
 
 func summarizeText(value string) string {
@@ -1208,11 +1290,25 @@ func formatThreshold(value float64) string {
 	return fmt.Sprintf("%.2f", value)
 }
 
+func formatFloatOrDefault(value float64, fallback string) string {
+	if value == 0 {
+		return fallback
+	}
+	return fmt.Sprintf("%.2f", value)
+}
+
 func effectiveDensity(value int) int {
 	if value > 0 {
 		return value
 	}
 	return 80
+}
+
+func effectiveDither(value domain.DitherMode) string {
+	if value == "" {
+		return string(domain.DitherModeOff)
+	}
+	return string(value)
 }
 
 func max(a, b int) int {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -152,6 +152,34 @@ func TestImageCommandUpdatesPreview(t *testing.T) {
 	}
 }
 
+func TestFillFileCommandLoadsFillText(t *testing.T) {
+	model := NewModel()
+	path := filepath.Join(t.TempDir(), "message.txt")
+	if err := os.WriteFile(path, []byte("Happy Birthday\nFrom Letterpress"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	model.commandInput.SetValue("/fill-file " + path)
+	model = model.executeCurrentCommand()
+
+	if model.draft.TextFile != path {
+		t.Fatalf("draft.TextFile = %q, want %q", model.draft.TextFile, path)
+	}
+	if model.draft.Text != "Happy Birthday From Letterpress" {
+		t.Fatalf("draft.Text = %q", model.draft.Text)
+	}
+}
+
+func TestModeCommandAcceptsVectorMode(t *testing.T) {
+	model := NewModel()
+	model.commandInput.SetValue("/mode vector")
+	model = model.executeCurrentCommand()
+
+	if model.draft.ASCII.Mode != domain.ASCIIModeVector {
+		t.Fatalf("mode = %q", model.draft.ASCII.Mode)
+	}
+}
+
 func TestHeaderAndPromptRemainVisibleWithPreviewContent(t *testing.T) {
 	model := NewModel()
 	model.width = 100
@@ -179,6 +207,7 @@ func TestExportCommandDelegatesToASCIIExporter(t *testing.T) {
 	model := NewModel()
 	model.draft.ImagePath = "/tmp/test.png"
 	model.draft.Text = "HELLO"
+	model.draft.ASCII.Mode = domain.ASCIIModeHybrid
 
 	origExporter := composeAndWriteASCII
 	defer func() { composeAndWriteASCII = origExporter }()
@@ -203,8 +232,11 @@ func TestExportCommandDelegatesToASCIIExporter(t *testing.T) {
 	if gotImage != "/tmp/test.png" {
 		t.Fatalf("image path = %q, want %q", gotImage, "/tmp/test.png")
 	}
-	if gotASCII.Charset != "HELLO" {
-		t.Fatalf("ascii charset = %q, want %q", gotASCII.Charset, "HELLO")
+	if gotASCII.FillText != "HELLO" {
+		t.Fatalf("fill text = %q, want %q", gotASCII.FillText, "HELLO")
+	}
+	if gotASCII.EffectiveToneCharset() == "HELLO" {
+		t.Fatalf("tone charset should not be derived from fill text")
 	}
 	if gotExport.Format != exportpkg.ASCIIFormatTXT {
 		t.Fatalf("export format = %q, want %q", gotExport.Format, exportpkg.ASCIIFormatTXT)
@@ -225,6 +257,7 @@ func TestRefreshPreviewUsesComposeASCII(t *testing.T) {
 		return &renderpkg.ASCIIComposition{
 			Page: renderpkg.Page{Size: page.Size, Orientation: page.Orientation},
 			Art: asciipkg.Art{
+				Mode:   domain.ASCIIModeTone,
 				Width:  3,
 				Height: 1,
 				Lines:  []string{"ABC"},

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -180,6 +180,16 @@ func TestModeCommandAcceptsVectorMode(t *testing.T) {
 	}
 }
 
+func TestFillFontCommandUpdatesASCIIStyle(t *testing.T) {
+	model := NewModel()
+	model.commandInput.SetValue("/fill-font block")
+	model = model.executeCurrentCommand()
+
+	if model.draft.ASCII.FillFont != domain.FillFontBlock {
+		t.Fatalf("fill font = %q", model.draft.ASCII.FillFont)
+	}
+}
+
 func TestHeaderAndPromptRemainVisibleWithPreviewContent(t *testing.T) {
 	model := NewModel()
 	model.width = 100
@@ -234,6 +244,9 @@ func TestExportCommandDelegatesToASCIIExporter(t *testing.T) {
 	}
 	if gotASCII.FillText != "HELLO" {
 		t.Fatalf("fill text = %q, want %q", gotASCII.FillText, "HELLO")
+	}
+	if gotASCII.FillFont != domain.FillFontPlain {
+		t.Fatalf("fill font = %q, want %q", gotASCII.FillFont, domain.FillFontPlain)
 	}
 	if gotASCII.EffectiveToneCharset() == "HELLO" {
 		t.Fatalf("tone charset should not be derived from fill text")


### PR DESCRIPTION
## Summary
- separate tone charset semantics from user fill text in the ASCII pipeline
- add improved raster text-art modes and a vector contour PDF beta path
- extend the slash-command TUI to configure the new quality controls and rendering modes

## What Changed
- expanded `domain.ASCIIOptions` with explicit mode, tone charset, fill text, gamma, edge threshold, dither, and cell aspect controls
- rebuilt the raster renderer with auto-level normalization, gamma/contrast handling, Sobel edges, occupancy-based fill rendering, dithering, and mode-specific output for `tone`, `outline`, `fill`, `hybrid`, and `vector`
- added contour segment extraction and a PDF-only vector beta export path that lays repeated fill text along contour-aligned segments
- updated the TUI slash shell with `/fill-file`, `/fill-text`, `/tone-charset`, `/mode tone|outline|fill|hybrid|vector`, `/gamma`, `/edge-threshold`, `/dither`, and `/cell-aspect`
- expanded tests across domain, render, export, ascii, and TUI behavior

## Verification
- go test ./...
- manual smoke export using local `test.png` and `test.txt` through the new hybrid/vector code paths

Closes #50
